### PR TITLE
feat: 사전 등록 상품 목록 조회에 isSeller 추가

### DIFF
--- a/src/main/java/org/chzz/market/domain/product/dto/ProductResponse.java
+++ b/src/main/java/org/chzz/market/domain/product/dto/ProductResponse.java
@@ -11,8 +11,21 @@ import lombok.Getter;
 @Getter
 public class ProductResponse extends BaseProductDto {
     private final Long productId;
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Boolean isLiked;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean isSeller;
+
+    @QueryProjection
+    public ProductResponse(Long productId, String name, String cdnPath, Integer minPrice,
+                           Long likeCount, Boolean isLiked, Boolean isSeller) {
+        super(name, cdnPath, likeCount, minPrice);
+        this.productId = productId;
+        this.isLiked = isLiked;
+        this.isSeller = isSeller;
+    }
 
     @QueryProjection
     public ProductResponse(Long productId, String name, String cdnPath, Integer minPrice,

--- a/src/main/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImpl.java
@@ -60,7 +60,8 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                         image.cdnPath,
                         product.minPrice,
                         product.likes.size().longValue(),
-                        isProductLikedByUser(userId)
+                        isProductLikedByUser(userId),
+                        product.user.id.eq(userId)
                 ))
                 .leftJoin(image).on(image.product.eq(product).and(isRepresentativeImage()))
                 .groupBy(product.id, product.name, image.cdnPath, product.minPrice)


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-178]

## 📝작업 내용


- 사전 등록 상품 목록 조회 응답에 판매자임을 확인해주는 `isSeller` 필드 추가


[CHZZ-178]: https://chzz-market.atlassian.net/browse/CHZZ-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ