### PR TITLE
refactor: 경매 삭제 API 전환

### DIFF
--- a/src/main/java/org/chzz/market/common/config/AWSConfig.java
+++ b/src/main/java/org/chzz/market/common/config/AWSConfig.java
@@ -19,6 +19,9 @@ public class AWSConfig {
     @Value("${cloud.aws.region.static}")
     private String region;
 
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
     @Bean
     public AmazonS3 amazonS3Client() {
         BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
@@ -26,5 +29,10 @@ public class AWSConfig {
                 .withRegion(region)
                 .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
                 .build();
+    }
+
+    @Bean
+    public String s3BucketName() {
+        return bucket;
     }
 }

--- a/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailApi.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailApi.java
@@ -1,15 +1,23 @@
 package org.chzz.market.domain.auctionv2.controller;
 
+import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.Const.AUCTION_ACCESS_FORBIDDEN;
+import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.Const.AUCTION_NOT_FOUND;
+import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.Const.OFFICIAL_AUCTION_DELETE_FORBIDDEN;
+import static org.chzz.market.domain.imagev2.error.ImageErrorCode.Const.IMAGE_DELETE_FAILED;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.Map;
 import org.chzz.market.common.config.LoginUser;
+import org.chzz.market.common.springdoc.ApiExceptionExplanation;
+import org.chzz.market.common.springdoc.ApiResponseExplanations;
 import org.chzz.market.domain.auction.dto.response.StartAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.WonAuctionDetailsResponse;
+import org.chzz.market.domain.auctionv2.error.AuctionErrorCode;
 import org.chzz.market.domain.bid.dto.response.BidInfoResponse;
+import org.chzz.market.domain.imagev2.error.ImageErrorCode;
 import org.chzz.market.domain.like.dto.LikeResponse;
-import org.chzz.market.domain.product.dto.DeleteProductResponse;
 import org.chzz.market.domain.product.dto.UpdateProductRequest;
 import org.chzz.market.domain.product.dto.UpdateProductResponse;
 import org.springdoc.core.annotations.ParameterObject;
@@ -64,9 +72,16 @@ public interface AuctionDetailApi {
                                                         @RequestPart @Valid UpdateProductRequest request,
                                                         @RequestParam(required = false) Map<String, MultipartFile> images);
 
-    @Operation(summary = "특정 경매 삭제", description = "특정 경매를 삭제합니다.")
+    @Operation(summary = "특정 경매 삭제", description = "특정 경매를 삭제합니다. 삭제는 사전경매만 가능합니다.")
+    @ApiResponseExplanations(
+            errors = {
+                    @ApiExceptionExplanation(value = AuctionErrorCode.class, constant = OFFICIAL_AUCTION_DELETE_FORBIDDEN, name = "정식 경매 인 경우"),
+                    @ApiExceptionExplanation(value = AuctionErrorCode.class, constant = AUCTION_ACCESS_FORBIDDEN, name = "경매의 접근 권한이 없는 경우"),
+                    @ApiExceptionExplanation(value = AuctionErrorCode.class, constant = AUCTION_NOT_FOUND, name = "경매를 찾을 수 없는 경우"),
+                    @ApiExceptionExplanation(value = ImageErrorCode.class, constant = IMAGE_DELETE_FAILED, name = "이미지 삭제에 실패한 경우"),
+            }
+    )
     @DeleteMapping
-    ResponseEntity<DeleteProductResponse> deleteAuction(@LoginUser Long userId,
-                                                        @PathVariable Long auctionId);
-
+    ResponseEntity<Void> deleteAuction(@LoginUser Long userId,
+                                       @PathVariable Long auctionId);
 }

--- a/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailController.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailController.java
@@ -1,11 +1,12 @@
 package org.chzz.market.domain.auctionv2.controller;
 
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import org.chzz.market.domain.auction.dto.response.StartAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.WonAuctionDetailsResponse;
+import org.chzz.market.domain.auctionv2.service.AuctionDeleteService;
 import org.chzz.market.domain.bid.dto.response.BidInfoResponse;
 import org.chzz.market.domain.like.dto.LikeResponse;
-import org.chzz.market.domain.product.dto.DeleteProductResponse;
 import org.chzz.market.domain.product.dto.UpdateProductRequest;
 import org.chzz.market.domain.product.dto.UpdateProductResponse;
 import org.springframework.data.domain.Page;
@@ -15,7 +16,10 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 //@RestController
+@RequiredArgsConstructor
 public class AuctionDetailController implements AuctionDetailApi {
+    private final AuctionDeleteService auctionDeleteService;
+
     @Override
     public ResponseEntity<?> getAuctionDetails(Long userId, Long auctionId) {
         return null;
@@ -49,7 +53,8 @@ public class AuctionDetailController implements AuctionDetailApi {
     }
 
     @Override
-    public ResponseEntity<DeleteProductResponse> deleteAuction(Long userId, Long auctionId) {
-        return null;
+    public ResponseEntity<Void> deleteAuction(Long userId, Long auctionId) {
+        auctionDeleteService.delete(userId, auctionId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/chzz/market/domain/auctionv2/entity/AuctionStatus.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/entity/AuctionStatus.java
@@ -1,0 +1,14 @@
+package org.chzz.market.domain.auctionv2.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AuctionStatus {
+    PROCEEDING("진행중"),
+    ENDED("종료됨"),
+    PRE("사전경매");
+
+    private final String description;
+}

--- a/src/main/java/org/chzz/market/domain/auctionv2/entity/AuctionV2.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/entity/AuctionV2.java
@@ -27,9 +27,7 @@ import org.chzz.market.domain.base.entity.BaseTimeEntity;
 import org.chzz.market.domain.image.entity.ImageV2;
 import org.chzz.market.domain.user.entity.User;
 
-/**
- * TODO: V2 경매 API 전환이 끝나서 운영 환경에 적용할 땐 기존 테이블에서 데이터를 이관해야 합니다.(flyway 스크립트)
- */
+// TODO: V2 경매 API 전환이 끝나서 운영 환경에 적용할 땐 기존 테이블에서 데이터를 이관해야 합니다.(flyway 스크립트)
 @Table(name = "auction_v2")
 @Entity
 @EntityListeners(value = AuctionEntityListener.class)

--- a/src/main/java/org/chzz/market/domain/auctionv2/entity/AuctionV2.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/entity/AuctionV2.java
@@ -1,5 +1,6 @@
 package org.chzz.market.domain.auctionv2.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -11,8 +12,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,18 +24,19 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.chzz.market.domain.auction.entity.listener.AuctionEntityListener;
 import org.chzz.market.domain.base.entity.BaseTimeEntity;
-import org.chzz.market.domain.product.entity.Product.Category;
+import org.chzz.market.domain.image.entity.ImageV2;
 import org.chzz.market.domain.user.entity.User;
 
 /**
  * TODO: V2 경매 API 전환이 끝나서 운영 환경에 적용할 땐 기존 테이블에서 데이터를 이관해야 합니다.(flyway 스크립트)
  */
-@Entity
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(value = AuctionEntityListener.class)
 @Table(name = "auction_v2")
+@Entity
+@EntityListeners(value = AuctionEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@AllArgsConstructor
+@Getter
 public class AuctionV2 extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -71,13 +76,23 @@ public class AuctionV2 extends BaseTimeEntity {
     @Column
     private Integer bidCount;
 
-    @Getter
-    @AllArgsConstructor
-    public enum AuctionStatus {
-        PROCEEDING("진행중"),
-        ENDED("종료"),
-        PRE("사전");
+    @Builder.Default
+    @OneToMany(mappedBy = "auction", cascade = {CascadeType.REMOVE, CascadeType.PERSIST}, orphanRemoval = true)
+    private List<ImageV2> images = new ArrayList<>();
 
-        private final String description;
+    public boolean isNowOwner(Long userId) {
+        return !isOwner(userId);
+    }
+
+    public boolean isOwner(Long userId) {
+        return seller.getId().equals(userId);
+    }
+
+    public boolean isPreAuction() {
+        return status == AuctionStatus.PRE;
+    }
+
+    public boolean isOfficialAuction() {
+        return status == AuctionStatus.PROCEEDING || status == AuctionStatus.ENDED;
     }
 }

--- a/src/main/java/org/chzz/market/domain/auctionv2/entity/Category.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/entity/Category.java
@@ -1,0 +1,19 @@
+package org.chzz.market.domain.auctionv2.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Category {
+    ELECTRONICS("전자기기"),
+    HOME_APPLIANCES("가전제품"),
+    FASHION_AND_CLOTHING("패션 및 의류"),
+    FURNITURE_AND_INTERIOR("가구 및 인테리어"),
+    BOOKS_AND_MEDIA("도서 및 미디어"),
+    SPORTS_AND_LEISURE("스포츠 및 레저"),
+    TOYS_AND_HOBBIES("장난감 및 취미"),
+    OTHER("기타");
+
+    private final String displayName;
+}

--- a/src/main/java/org/chzz/market/domain/auctionv2/error/AuctionErrorCode.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/error/AuctionErrorCode.java
@@ -1,0 +1,26 @@
+package org.chzz.market.domain.auctionv2.error;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.chzz.market.common.error.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuctionErrorCode implements ErrorCode {
+    OFFICIAL_AUCTION_DELETE_FORBIDDEN(FORBIDDEN, "정식경매는 삭제할수 없습니다."),
+    AUCTION_ACCESS_FORBIDDEN(FORBIDDEN, "해당 경매에 접근할 수 없습니다."),
+    AUCTION_NOT_FOUND(NOT_FOUND, "경매를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public static class Const {
+        public static final String OFFICIAL_AUCTION_DELETE_FORBIDDEN = "OFFICIAL_AUCTION_DELETE_FORBIDDEN";
+        public static final String AUCTION_ACCESS_FORBIDDEN = "AUCTION_ACCESS_FORBIDDEN";
+        public static final String AUCTION_NOT_FOUND = "AUCTION_NOT_FOUND";
+    }
+}

--- a/src/main/java/org/chzz/market/domain/auctionv2/error/AuctionException.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/error/AuctionException.java
@@ -1,0 +1,10 @@
+package org.chzz.market.domain.auctionv2.error;
+
+import org.chzz.market.common.error.ErrorCode;
+import org.chzz.market.common.error.exception.BusinessException;
+
+public class AuctionException extends BusinessException {
+    public AuctionException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/chzz/market/domain/auctionv2/service/AuctionDeleteService.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/service/AuctionDeleteService.java
@@ -1,0 +1,66 @@
+package org.chzz.market.domain.auctionv2.service;
+
+import static org.chzz.market.domain.notification.entity.NotificationType.PRE_AUCTION_CANCELED;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.chzz.market.domain.auctionv2.entity.AuctionV2;
+import org.chzz.market.domain.auctionv2.error.AuctionErrorCode;
+import org.chzz.market.domain.auctionv2.error.AuctionException;
+import org.chzz.market.domain.auctionv2.repository.AuctionV2Repository;
+import org.chzz.market.domain.imagev2.service.ImageDeleteService;
+import org.chzz.market.domain.likev2.repository.LikeV2Repository;
+import org.chzz.market.domain.notification.event.NotificationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuctionDeleteService {
+    private final ImageDeleteService imageDeleteService;
+    private final AuctionV2Repository auctionRepository;
+    private final LikeV2Repository likeRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    /**
+     * 경매 삭제 (사전등록만 가능)
+     */
+    @Transactional
+    public void delete(Long userId, Long auctionId) {
+        AuctionV2 auction = auctionRepository.findById(auctionId) // TODO: 패치 조인으로 쿼리 성능 개선 필요(Seller, Image) n+1 문제
+                .orElseThrow(() -> new AuctionException(AuctionErrorCode.AUCTION_NOT_FOUND));
+        validate(userId, auction);
+        imageDeleteService.deleteImages(auction.getImages());
+        auctionRepository.delete(auction);
+        processDeleteNotification(auction);
+    }
+
+    /**
+     * 경매 취소 유효성 검사
+     */
+    private static void validate(Long userId, AuctionV2 auction) {
+        if (auction.isNowOwner(userId)) {
+            throw new AuctionException(AuctionErrorCode.AUCTION_ACCESS_FORBIDDEN);
+        }
+        if (auction.isOfficialAuction()) {
+            throw new AuctionException(AuctionErrorCode.OFFICIAL_AUCTION_DELETE_FORBIDDEN);
+        }
+    }
+
+    /**
+     * 사전 경매 취소 알림 이벤트 발행
+     */
+    private void processDeleteNotification(AuctionV2 auction) {
+        // 1. 해당 경매에 좋아요 누른 사용자 ID 추출
+        List<Long> likedUserIds = likeRepository.findByAuctionId(auction.getId()).stream().map(like -> like.getUserId())
+                .toList();
+
+        // 2. 사젼 경매 취소 알림 이벤트 발행
+        if (!likedUserIds.isEmpty()) {
+            eventPublisher.publishEvent(NotificationEvent.createSimpleNotification(likedUserIds, PRE_AUCTION_CANCELED,
+                    PRE_AUCTION_CANCELED.getMessage(auction.getName()), null));
+        }
+    }
+}

--- a/src/main/java/org/chzz/market/domain/imagev2/entity/ImageV2.java
+++ b/src/main/java/org/chzz/market/domain/imagev2/entity/ImageV2.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 import org.chzz.market.domain.auctionv2.entity.AuctionV2;
 import org.chzz.market.domain.base.entity.BaseTimeEntity;
 
+// TODO: V2 경매 API 전환이 끝나서 운영 환경에 적용할 땐 기존 테이블에서 데이터를 이관해야 합니다.(flyway 스크립트)
 @Getter
 @Entity
 @Table(indexes = {
@@ -26,7 +27,7 @@ import org.chzz.market.domain.base.entity.BaseTimeEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-public class ImageV2 extends BaseTimeEntity { // TODO: V2 경매 API 전환이 끝나서 운영 환경에 적용할 땐 기존 테이블에서 데이터를 이관해야 합니다.(flyway 스크립트)
+public class ImageV2 extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "image_id")

--- a/src/main/java/org/chzz/market/domain/imagev2/entity/ImageV2.java
+++ b/src/main/java/org/chzz/market/domain/imagev2/entity/ImageV2.java
@@ -1,0 +1,52 @@
+package org.chzz.market.domain.image.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.chzz.market.domain.auctionv2.entity.AuctionV2;
+import org.chzz.market.domain.base.entity.BaseTimeEntity;
+
+@Getter
+@Entity
+@Table(indexes = {
+        @Index(columnList = "auction_id, image_id, cdn_path")
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class ImageV2 extends BaseTimeEntity { // TODO: V2 경매 API 전환이 끝나서 운영 환경에 적용할 땐 기존 테이블에서 데이터를 이관해야 합니다.(flyway 스크립트)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "auction_id")
+    private AuctionV2 auction;
+
+    @Column(nullable = false)
+    private String cdnPath;
+
+    @Column
+    private int sequence;
+
+    public void specifyAuction(AuctionV2 auction) {
+        this.auction = auction;
+    }
+
+    public void changeSequence(Integer newSequence) {
+        this.sequence = newSequence;
+    }
+}

--- a/src/main/java/org/chzz/market/domain/imagev2/error/ImageErrorCode.java
+++ b/src/main/java/org/chzz/market/domain/imagev2/error/ImageErrorCode.java
@@ -1,0 +1,19 @@
+package org.chzz.market.domain.imagev2.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.chzz.market.common.error.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ImageErrorCode implements ErrorCode {
+    IMAGE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제를 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public static class Const {
+        public static final String IMAGE_DELETE_FAILED = "IMAGE_DELETE_FAILED";
+    }
+}

--- a/src/main/java/org/chzz/market/domain/imagev2/error/exception/ImageException.java
+++ b/src/main/java/org/chzz/market/domain/imagev2/error/exception/ImageException.java
@@ -1,0 +1,10 @@
+package org.chzz.market.domain.imagev2.error.exception;
+
+import org.chzz.market.common.error.ErrorCode;
+import org.chzz.market.common.error.exception.BusinessException;
+
+public class ImageException extends BusinessException {
+    public ImageException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/chzz/market/domain/imagev2/service/ImageDeleteService.java
+++ b/src/main/java/org/chzz/market/domain/imagev2/service/ImageDeleteService.java
@@ -1,0 +1,50 @@
+package org.chzz.market.domain.imagev2.service;
+
+import static org.chzz.market.domain.imagev2.error.ImageErrorCode.IMAGE_DELETE_FAILED;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.chzz.market.domain.image.entity.ImageV2;
+import org.chzz.market.domain.imagev2.error.exception.ImageException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class ImageDeleteService {
+    private final AmazonS3 amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    /**
+     * S3에서 이미지 삭제
+     */
+    public void deleteImages(List<ImageV2> images) {
+        images.stream()
+                .map(ImageV2::getCdnPath)
+                .forEach(this::deleteImage);
+    }
+
+    /**
+     * 단일 이미지 삭제
+     */
+    private void deleteImage(String cdnPath) {
+        try {
+            String key = new URL(cdnPath).getPath().substring(1);
+            amazonS3Client.deleteObject(bucket, key);
+            log.info("S3에서 객체 삭제, Key : {}", key);
+        } catch (AmazonServiceException | MalformedURLException e) {
+            throw new ImageException(IMAGE_DELETE_FAILED);
+        }
+    }
+}
+

--- a/src/main/java/org/chzz/market/domain/imagev2/service/ImageDeleteService.java
+++ b/src/main/java/org/chzz/market/domain/imagev2/service/ImageDeleteService.java
@@ -7,23 +7,24 @@ import com.amazonaws.services.s3.AmazonS3;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.chzz.market.domain.image.entity.ImageV2;
 import org.chzz.market.domain.imagev2.error.exception.ImageException;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
-@RequiredArgsConstructor
 @Slf4j
 public class ImageDeleteService {
     private final AmazonS3 amazonS3Client;
+    private final String bucket;
 
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
+    public ImageDeleteService(AmazonS3 amazonS3Client, @Qualifier("s3BucketName") String bucket) {
+        this.amazonS3Client = amazonS3Client;
+        this.bucket = bucket;
+    }
 
     /**
      * S3에서 이미지 삭제

--- a/src/main/java/org/chzz/market/domain/likev2/entity/LikeV2.java
+++ b/src/main/java/org/chzz/market/domain/likev2/entity/LikeV2.java
@@ -1,0 +1,37 @@
+package org.chzz.market.domain.likev2.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.chzz.market.domain.base.entity.BaseTimeEntity;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "likes",
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id", "auction_id"})}
+)
+public class LikeV2 extends BaseTimeEntity { // TODO: V2 경매 API 전환이 끝나서 운영 환경에 적용할 땐 기존 테이블에서 데이터를 이관해야 합니다.(flyway 스크립트)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Long auctionId;
+}

--- a/src/main/java/org/chzz/market/domain/likev2/entity/LikeV2.java
+++ b/src/main/java/org/chzz/market/domain/likev2/entity/LikeV2.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.chzz.market.domain.base.entity.BaseTimeEntity;
 
+// TODO: V2 경매 API 전환이 끝나서 운영 환경에 적용할 땐 기존 테이블에서 데이터를 이관해야 합니다.(flyway 스크립트)
 @Getter
 @Entity
 @Builder
@@ -23,7 +24,7 @@ import org.chzz.market.domain.base.entity.BaseTimeEntity;
         name = "likes",
         uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id", "auction_id"})}
 )
-public class LikeV2 extends BaseTimeEntity { // TODO: V2 경매 API 전환이 끝나서 운영 환경에 적용할 땐 기존 테이블에서 데이터를 이관해야 합니다.(flyway 스크립트)
+public class LikeV2 extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "like_id")

--- a/src/main/java/org/chzz/market/domain/likev2/repository/LikeV2Repository.java
+++ b/src/main/java/org/chzz/market/domain/likev2/repository/LikeV2Repository.java
@@ -1,0 +1,9 @@
+package org.chzz.market.domain.likev2.repository;
+
+import java.util.List;
+import org.chzz.market.domain.likev2.entity.LikeV2;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeV2Repository extends JpaRepository<LikeV2, Long> {
+    List<LikeV2> findByAuctionId(Long auctionId);
+}

--- a/src/main/resources/db/migration/V15__create_like_image.sql
+++ b/src/main/resources/db/migration/V15__create_like_image.sql
@@ -1,0 +1,32 @@
+-- 파일명: V15__create_like_image.sql
+-- 파일 설명: v2 like, image
+-- 작성일: 2024-11-12
+-- 참고: 이 파일은 Flyway 명명 규칙 "V<버전번호>__<설명>.sql"을 따릅니다.
+--      적용된 후에는 절대 수정할 수 없으므로, 수정이 필요한 경우에는 새로운 마이그레이션 파일을 작성해 주세요.
+
+CREATE TABLE imagev2
+(
+    image_id   BIGINT AUTO_INCREMENT NOT NULL,
+    auction_id BIGINT                NULL,
+    cdn_path   VARCHAR(255)          NOT NULL,
+    sequence   INT                   NULL,
+    created_at datetime              NULL,
+    updated_at datetime              NULL,
+    CONSTRAINT pk_imagev2 PRIMARY KEY (image_id)
+);
+
+CREATE TABLE likes
+(
+    like_id    BIGINT AUTO_INCREMENT NOT NULL,
+    user_id    BIGINT                NOT NULL,
+    auction_id BIGINT                NOT NULL,
+    created_at datetime              NULL,
+    updated_at datetime              NULL,
+    CONSTRAINT pk_likes PRIMARY KEY (like_id),
+    CONSTRAINT uc_likes_user_auction UNIQUE (user_id, auction_id)
+);
+
+CREATE INDEX idx_15d5b1726f3551b467ed898fd ON imagev2 (auction_id, image_id, cdn_path);
+
+ALTER TABLE imagev2
+    ADD CONSTRAINT FK_IMAGEV2_ON_AUCTION FOREIGN KEY (auction_id) REFERENCES auction_v2 (auction_id);

--- a/src/test/java/org/chzz/market/domain/auctionv2/service/AuctionDeleteServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/auctionv2/service/AuctionDeleteServiceTest.java
@@ -1,0 +1,128 @@
+package org.chzz.market.domain.auctionv2.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.AUCTION_ACCESS_FORBIDDEN;
+import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.AUCTION_NOT_FOUND;
+import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.OFFICIAL_AUCTION_DELETE_FORBIDDEN;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.chzz.market.domain.auctionv2.entity.AuctionV2;
+import org.chzz.market.domain.auctionv2.error.AuctionException;
+import org.chzz.market.domain.auctionv2.repository.AuctionV2Repository;
+import org.chzz.market.domain.imagev2.service.ImageDeleteService;
+import org.chzz.market.domain.likev2.entity.LikeV2;
+import org.chzz.market.domain.likev2.repository.LikeV2Repository;
+import org.chzz.market.domain.notification.event.NotificationEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class AuctionDeleteServiceTest {
+    private static final String ERROR_CODE = "errorCode";
+
+    @Mock
+    private ImageDeleteService imageDeleteService;
+    @Mock
+    private AuctionV2Repository auctionRepository;
+    @Mock
+    private LikeV2Repository likeRepository;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private AuctionDeleteService auctionDeleteService;
+
+    @Test
+    void 정상_삭제_테스트() {
+        // given
+        AuctionV2 auction = mock(AuctionV2.class);
+        LikeV2 like = mock(LikeV2.class);
+
+        when(auctionRepository.findById(any())).thenReturn(Optional.of(auction));
+        when(auction.isNowOwner(any())).thenReturn(false);
+        when(auction.isOfficialAuction()).thenReturn(false);
+        when(likeRepository.findByAuctionId(auction.getId())).thenReturn(List.of(like));
+
+        // when
+        auctionDeleteService.delete(1L, 1L);
+
+        // then
+        verify(imageDeleteService, times(1)).deleteImages(auction.getImages());
+        verify(auctionRepository, times(1)).delete(auction);
+        verify(eventPublisher, times(1)).publishEvent(any(NotificationEvent.class));
+    }
+
+    @Test
+    void 정상_삭제_테스트_좋아요_누른사람이_없을때_알림이벤트발행_하지않는다() {
+        // given
+        AuctionV2 auction = mock(AuctionV2.class);
+
+        when(auctionRepository.findById(any())).thenReturn(Optional.of(auction));
+        when(auction.isNowOwner(any())).thenReturn(false);
+        when(auction.isOfficialAuction()).thenReturn(false);
+        when(likeRepository.findByAuctionId(auction.getId())).thenReturn(List.of());
+
+        // when
+        auctionDeleteService.delete(1L, 1L);
+
+        // then
+        verify(imageDeleteService, times(1)).deleteImages(auction.getImages());
+        verify(auctionRepository, times(1)).delete(auction);
+        verify(eventPublisher, times(0)).publishEvent(any(NotificationEvent.class));
+    }
+
+    @Test
+    void 해당_경매를_찾을수_없을때_예외가_발생한다() {
+        // when
+        when(auctionRepository.findById(any())).thenReturn(Optional.empty());
+
+        // then
+        assertThatThrownBy(() -> auctionDeleteService.delete(1L, 1L))
+                .isInstanceOf(AuctionException.class)
+                .extracting(ERROR_CODE)
+                .isEqualTo(AUCTION_NOT_FOUND);
+    }
+
+    @Test
+    void 해당_경매에_주인이_아닐때_삭제시도_할경우_예외가_발생한다() {
+        // given
+        AuctionV2 auction = mock(AuctionV2.class);
+
+        // when
+        when(auctionRepository.findById(any())).thenReturn(Optional.of(auction));
+        when(auction.isNowOwner(any())).thenReturn(true);
+
+        // then
+        assertThatThrownBy(() -> auctionDeleteService.delete(1L, 1L))
+                .isInstanceOf(AuctionException.class)
+                .extracting(ERROR_CODE)
+                .isEqualTo(AUCTION_ACCESS_FORBIDDEN);
+    }
+
+    @Test
+    void 사전경매가_아닐때_삭제시도_할경우_예외가_발생한다() {
+        // given
+        AuctionV2 auction = mock(AuctionV2.class);
+
+        // when
+        when(auctionRepository.findById(any())).thenReturn(Optional.of(auction));
+        when(auction.isNowOwner(any())).thenReturn(false);
+        when(auction.isOfficialAuction()).thenReturn(true);
+
+        // then
+        assertThatThrownBy(() -> auctionDeleteService.delete(1L, 1L))
+                .isInstanceOf(AuctionException.class)
+                .extracting(ERROR_CODE)
+                .isEqualTo(OFFICIAL_AUCTION_DELETE_FORBIDDEN);
+    }
+}

--- a/src/test/java/org/chzz/market/domain/imagev2/service/ImageDeleteServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/imagev2/service/ImageDeleteServiceTest.java
@@ -1,0 +1,83 @@
+package org.chzz.market.domain.imagev2.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.chzz.market.domain.imagev2.error.ImageErrorCode.IMAGE_DELETE_FAILED;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import java.util.List;
+import org.chzz.market.domain.image.entity.ImageV2;
+import org.chzz.market.domain.imagev2.error.exception.ImageException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ImageDeleteServiceTest {
+    private static final String ERROR_CODE = "errorCode";
+    private final String bucket = "test-bucket";
+    private final String cdnPath1 = "https://test-bucket.s3.amazonaws.com/image1.jpg";
+    private final String cdnPath2 = "https://test-bucket.s3.amazonaws.com/image2.jpg";
+
+    @Mock
+    private AmazonS3 amazonS3Client;
+
+    private ImageDeleteService imageDeleteService;
+
+    @BeforeEach
+    void setUp() {
+        imageDeleteService = new ImageDeleteService(amazonS3Client, bucket);
+    }
+
+    @Test
+    void 이미지_삭제_성공() {
+        // given
+        ImageV2 image1 = mock(ImageV2.class);
+        ImageV2 image2 = mock(ImageV2.class);
+
+        when(image1.getCdnPath()).thenReturn(cdnPath1);
+        when(image2.getCdnPath()).thenReturn(cdnPath2);
+
+        // when
+        imageDeleteService.deleteImages(List.of(image1, image2));
+
+        // then
+        verify(amazonS3Client, times(1)).deleteObject(bucket, "image1.jpg");
+        verify(amazonS3Client, times(1)).deleteObject(bucket, "image2.jpg");
+    }
+
+    @Test
+    void S3_에러로_이미지삭제시_예외발생() {
+        // given
+        ImageV2 image = mock(ImageV2.class);
+        when(image.getCdnPath()).thenReturn(cdnPath1);
+
+        doThrow(AmazonServiceException.class).when(amazonS3Client).deleteObject(bucket, "image1.jpg");
+
+        // when & then
+        assertThatThrownBy(() -> imageDeleteService.deleteImages(List.of(image)))
+                .isInstanceOf(ImageException.class)
+                .extracting(ERROR_CODE)
+                .isEqualTo(IMAGE_DELETE_FAILED);
+    }
+
+    @Test
+    void 잘못된_URL_이미지_삭제시_예외발생() {
+        // given
+        ImageV2 image = mock(ImageV2.class);
+        when(image.getCdnPath()).thenReturn("invalid-url");
+
+        // when & then
+        assertThatThrownBy(() -> imageDeleteService.deleteImages(List.of(image)))
+                .isInstanceOf(ImageException.class)
+                .extracting(ERROR_CODE)
+                .isEqualTo(IMAGE_DELETE_FAILED);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-181]

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 경매 삭제 API를 전환하였습니다.

- [ ] 정식 경매 목록 조회
- [ ] 사전 경매 목록 조회
- [ ] 정식 경매 베스트 조회
- [ ] 정식 경매 마감임박 조회
- [ ] 경매 카테고리 조회
- [ ] 내가 등록한 진행 중인 경매 목록 조회
- [ ] 내가 등록한 종료된 경매 목록 조회
- [ ] 내가 등록한 사전 경매 목록 조회
- [ ] 내가 성공(낙찰)한 경매 목록 조회
- [ ] 내가 실패한(낙찰 실패) 경매 목록 조회
- [ ] 내가 좋아요(찜)한 경매 목록 조회
- [ ] 경매 등록
- [ ] 테스트 경매 추가
- [ ] 경매 상세 조회
- [ ] 경매 입찰 목록 조회
- [ ] 경매 낙찰 정보 조회
- [ ] 사전 경매에서 정식 경매로 전환
- [ ] (사전) 경매 좋아요(찜) 요청 및 취소
- [ ] (사전) 경매 수정
- [x] (사전) 경매 취소

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

![스크린샷 2024-11-12 오후 4 45 23](https://github.com/user-attachments/assets/c7b4262a-0fbb-4bde-be00-99c4f8a77ba0)

![스크린샷 2024-11-12 오후 5 32 19](https://github.com/user-attachments/assets/6333a056-727c-493d-8358-7981a6c0a00a)


## 🙏리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->

- 서비스 함수 테스트 코드 작성방법이 맞는지 확인해주세요.
