### PR TITLE
refactor: 경매 상세 정보 조회 API 전환

### DIFF
--- a/src/main/java/org/chzz/market/common/config/SecurityConfig.java
+++ b/src/main/java/org/chzz/market/common/config/SecurityConfig.java
@@ -72,7 +72,8 @@ public class SecurityConfig {
                                 "/api/v1/users/*",
                                 "/api/v1/users/check/nickname/*").permitAll()
                         .requestMatchers(GET,
-                                "/api/v2/auctions/categories").permitAll()
+                                "/api/v2/auctions/categories",
+                                "/api/v2/auctions/{auctionId:\\d+}").permitAll()
                         .requestMatchers(POST,
                                 "/api/v1/users/tokens/reissue").permitAll()
                         .requestMatchers(POST, "/api/v1/users").hasRole("TEMP_USER")

--- a/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailApi.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailApi.java
@@ -9,12 +9,18 @@ import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.Const.OFFI
 import static org.chzz.market.domain.imagev2.error.ImageErrorCode.Const.IMAGE_DELETE_FAILED;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.Map;
 import org.chzz.market.common.config.LoginUser;
 import org.chzz.market.common.springdoc.ApiExceptionExplanation;
 import org.chzz.market.common.springdoc.ApiResponseExplanations;
+import org.chzz.market.domain.auctionv2.dto.response.OfficialAuctionDetailResponse;
+import org.chzz.market.domain.auctionv2.dto.response.PreAuctionDetailResponse;
 import org.chzz.market.domain.auctionv2.dto.response.WonAuctionDetailsResponse;
 import org.chzz.market.domain.auctionv2.error.AuctionErrorCode;
 import org.chzz.market.domain.bid.dto.response.BidInfoResponse;
@@ -27,6 +33,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -36,7 +43,10 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "auctions(v2)", description = "V2 경매 API")
 public interface AuctionDetailApi {
     @Operation(summary = "특정 경매 상세 조회", description = "특정 경매 상세 정보를 조회합니다.")
-        // TODO: 정식경매와 사전 경매 응답 구분 추가
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "정식경매 응답", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = OfficialAuctionDetailResponse.class))),
+            @ApiResponse(responseCode = "201", description = "사전경매 응답", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PreAuctionDetailResponse.class))),
+    })
     ResponseEntity<?> getAuctionDetails(@LoginUser Long userId,
                                         @PathVariable Long auctionId);
 

--- a/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailController.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.chzz.market.common.config.LoginUser;
 import org.chzz.market.domain.auctionv2.dto.response.WonAuctionDetailsResponse;
 import org.chzz.market.domain.auctionv2.service.AuctionDeleteService;
+import org.chzz.market.domain.auctionv2.service.AuctionDetailService;
 import org.chzz.market.domain.auctionv2.service.AuctionStartService;
 import org.chzz.market.domain.auctionv2.service.AuctionWonService;
 import org.chzz.market.domain.bid.dto.response.BidInfoResponse;
@@ -32,6 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @RequestMapping("/v2/auctions/{auctionId}")
 public class AuctionDetailController implements AuctionDetailApi {
+    private final AuctionDetailService auctionDetailService;
     private final AuctionDeleteService auctionDeleteService;
     private final AuctionStartService auctionStartService;
     private final AuctionWonService auctionWonService;
@@ -39,8 +41,9 @@ public class AuctionDetailController implements AuctionDetailApi {
 
     @Override
     @GetMapping
-    public ResponseEntity<?> getAuctionDetails(@LoginUser Long userId, @PathVariable Long auctionId) {
-        return null;
+    public ResponseEntity<?> getAuctionDetails(@LoginUser Long userId,
+                                               @PathVariable Long auctionId) {
+        return ResponseEntity.ok(auctionDetailService.getAuctionDetails(userId, auctionId));
     }
 
     @Override

--- a/src/main/java/org/chzz/market/domain/auctionv2/dto/response/AuctionDetailBaseResponse.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/dto/response/AuctionDetailBaseResponse.java
@@ -1,0 +1,41 @@
+package org.chzz.market.domain.auctionv2.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
+import org.chzz.market.domain.auctionv2.entity.Category;
+import org.chzz.market.domain.image.dto.ImageResponse;
+
+@Getter
+@NoArgsConstructor
+public abstract class AuctionDetailBaseResponse {
+    private Long auctionId;
+    private String sellerNickname;
+    private String sellerProfileImageUrl;
+    private String productName;
+    private String description;
+    private Integer minPrice;
+    protected Boolean isSeller;
+    private AuctionStatus status;
+    private Category category;
+    private List<ImageResponse> images;
+
+    public AuctionDetailBaseResponse(Long auctionId, String sellerNickname, String sellerProfileImageUrl,
+                                     String productName, String description, Integer minPrice, Boolean isSeller,
+                                     AuctionStatus status, Category category) {
+        this.auctionId = auctionId;
+        this.sellerNickname = sellerNickname;
+        this.sellerProfileImageUrl = sellerProfileImageUrl;
+        this.productName = productName;
+        this.description = description;
+        this.minPrice = minPrice;
+        this.isSeller = isSeller;
+        this.status = status;
+        this.category = category;
+    }
+
+    public void addImageList(List<ImageResponse> images) {
+        this.images = images;
+    }
+}

--- a/src/main/java/org/chzz/market/domain/auctionv2/dto/response/OfficialAuctionDetailResponse.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/dto/response/OfficialAuctionDetailResponse.java
@@ -1,0 +1,54 @@
+package org.chzz.market.domain.auctionv2.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
+import org.chzz.market.domain.auctionv2.entity.Category;
+
+@Getter
+@NoArgsConstructor
+public class OfficialAuctionDetailResponse extends AuctionDetailBaseResponse {
+    private Long timeRemaining;
+    private Long participantCount;
+    private Boolean isParticipated;
+    private Long bidId;
+    private Long bidAmount;
+    private int remainingBidCount;
+    private Boolean isCancelled;
+    @Schema(description = "낙찰자인지 여부")
+    private Boolean isWinner;
+    @Schema(description = "낙찰되었는지 여부")
+    private Boolean isWon;
+    @Schema(description = "주문 여부 - 판매자와 낙찰자에게만 제공")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean isOrdered;
+
+    public OfficialAuctionDetailResponse(Long auctionId, String sellerNickname, String sellerProfileImageUrl,
+                                         String productName, String description, Integer minPrice, Boolean isSeller,
+                                         AuctionStatus status, Category category, Long timeRemaining,
+                                         Long participantCount, Boolean isParticipated, Long bidId, Long bidAmount,
+                                         int remainingBidCount, Boolean isCancelled, Boolean isWinner, Boolean isWon,
+                                         Boolean isOrdered) {
+        super(auctionId, sellerNickname, sellerProfileImageUrl, productName, description, minPrice, isSeller, status,
+                category);
+        this.timeRemaining = timeRemaining;
+        this.participantCount = participantCount;
+        this.isParticipated = isParticipated;
+        this.bidId = bidId;
+        this.bidAmount = bidAmount;
+        this.remainingBidCount = remainingBidCount;
+        this.isCancelled = isCancelled;
+        this.isWinner = isWinner;
+        this.isWon = isWon;
+        this.isOrdered = isOrdered;
+    }
+
+    public OfficialAuctionDetailResponse clearOrderIfNotEligible() {
+        if (!isSeller && !isWinner) {
+            this.isOrdered = null;
+        }
+        return this;
+    }
+}

--- a/src/main/java/org/chzz/market/domain/auctionv2/dto/response/PreAuctionDetailResponse.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/dto/response/PreAuctionDetailResponse.java
@@ -1,0 +1,26 @@
+package org.chzz.market.domain.auctionv2.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
+import org.chzz.market.domain.auctionv2.entity.Category;
+
+@Getter
+@NoArgsConstructor
+public class PreAuctionDetailResponse extends AuctionDetailBaseResponse {
+    private LocalDateTime updatedAt;
+    private Long likeCount;
+    private Boolean isLiked;
+
+    public PreAuctionDetailResponse(Long auctionId, String sellerNickname, String sellerProfileImageUrl,
+                                    String productName,
+                                    String description, Integer minPrice, Boolean isSeller, AuctionStatus status,
+                                    Category category, LocalDateTime updatedAt, Long likeCount, Boolean isLiked) {
+        super(auctionId, sellerNickname, sellerProfileImageUrl, productName, description, minPrice, isSeller, status,
+                category);
+        this.updatedAt = updatedAt;
+        this.likeCount = likeCount;
+        this.isLiked = isLiked;
+    }
+}

--- a/src/main/java/org/chzz/market/domain/auctionv2/entity/AuctionV2.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/entity/AuctionV2.java
@@ -79,11 +79,11 @@ public class AuctionV2 extends BaseTimeEntity {
 
     @Builder.Default
     @Column
-    private Integer likeCount = 0;
+    private Long likeCount = 0L;
 
     @Builder.Default
     @Column
-    private Integer bidCount = 0;
+    private Long bidCount = 0L;
 
     @Builder.Default
     @OneToMany(mappedBy = "auction", cascade = {CascadeType.REMOVE, CascadeType.PERSIST}, orphanRemoval = true)

--- a/src/main/java/org/chzz/market/domain/auctionv2/repository/AuctionV2QueryRepository.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/repository/AuctionV2QueryRepository.java
@@ -1,15 +1,32 @@
 package org.chzz.market.domain.auctionv2.repository;
 
+import static com.querydsl.core.types.dsl.Expressions.numberTemplate;
+import static org.chzz.market.common.util.QuerydslUtil.nullSafeBuilder;
 import static org.chzz.market.domain.auctionv2.entity.QAuctionV2.auctionV2;
+import static org.chzz.market.domain.bid.entity.Bid.BidStatus.ACTIVE;
+import static org.chzz.market.domain.bid.entity.Bid.BidStatus.CANCELLED;
 import static org.chzz.market.domain.bid.entity.QBid.bid;
 import static org.chzz.market.domain.image.entity.QImageV2.imageV2;
+import static org.chzz.market.domain.likev2.entity.QLikeV2.likeV2;
+import static org.chzz.market.domain.orderv2.entity.QOrderV2.orderV2;
+import static org.chzz.market.domain.user.entity.QUser.user;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.chzz.market.domain.auctionv2.dto.response.OfficialAuctionDetailResponse;
+import org.chzz.market.domain.auctionv2.dto.response.PreAuctionDetailResponse;
 import org.chzz.market.domain.auctionv2.dto.response.QWonAuctionDetailsResponse;
 import org.chzz.market.domain.auctionv2.dto.response.WonAuctionDetailsResponse;
+import org.chzz.market.domain.bid.entity.QBid;
+import org.chzz.market.domain.image.dto.ImageResponse;
+import org.chzz.market.domain.image.dto.QImageResponse;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -31,8 +48,119 @@ public class AuctionV2QueryRepository {
                 .fetchOne());
     }
 
+    public Optional<PreAuctionDetailResponse> findPreAuctionDetailById(Long userId, Long auctionId) {
+        Optional<PreAuctionDetailResponse> result = Optional.ofNullable(jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                PreAuctionDetailResponse.class,
+                                auctionV2.id,
+                                user.nickname,
+                                user.profileImageUrl,
+                                auctionV2.name,
+                                auctionV2.description,
+                                auctionV2.minPrice,
+                                userIdEq(userId),
+                                auctionV2.status,
+                                auctionV2.category,
+                                auctionV2.updatedAt,
+                                auctionV2.likeCount,
+                                isAuctionLikedByUserId(userId)
+                        )
+                )
+                .from(auctionV2)
+                .join(auctionV2.seller, user)
+                .where(auctionV2.id.eq(auctionId))
+                .fetchOne());
+
+        result.ifPresent(response -> response.addImageList(getImagesByAuctionId(response.getAuctionId())));
+        return result;
+    }
+
+    public Optional<OfficialAuctionDetailResponse> findOfficialAuctionDetailById(Long userId, Long auctionId) {
+        QBid activeBid = new QBid("bidActive");
+        QBid canceledBid = new QBid("bidCanceled");
+        Optional<OfficialAuctionDetailResponse> officialAuctionDetailResponse = Optional.ofNullable(jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                OfficialAuctionDetailResponse.class,
+                                auctionV2.id,
+                                user.nickname,
+                                user.profileImageUrl,
+                                auctionV2.name,
+                                auctionV2.description,
+                                auctionV2.minPrice,
+                                userIdEq(userId),
+                                auctionV2.status,
+                                auctionV2.category,
+                                timeRemaining().longValue(),
+                                auctionV2.bidCount,
+                                activeBid.id.isNotNull(),
+                                activeBid.id,
+                                activeBid.amount.coalesce(0L),
+                                activeBid.count.coalesce(3),
+                                canceledBid.id.isNotNull(),
+                                winnerIdEq(userId),
+                                auctionV2.winnerId.isNotNull(),
+                                orderV2.isNotNull()
+                        )
+                )
+                .from(auctionV2)
+                .join(auctionV2.seller, user)
+                .leftJoin(activeBid).on(activeBid.auctionId.eq(auctionId) // 활성화된 입찰 조인
+                        .and(activeBid.status.eq(ACTIVE))
+                        .and(bidderIdEqSub(activeBid, userId)))
+                .leftJoin(canceledBid).on(canceledBid.auctionId.eq(auctionId) // 취소된 입찰 조인
+                        .and(canceledBid.status.eq(CANCELLED))
+                        .and(bidderIdEqSub(canceledBid, userId)))
+                .leftJoin(orderV2).on(orderV2.auction.eq(auctionV2))
+                .where(auctionV2.id.eq(auctionId))
+                .fetchOne());
+
+        officialAuctionDetailResponse.ifPresent(
+                response -> response.addImageList(getImagesByAuctionId(response.getAuctionId())));
+
+        return officialAuctionDetailResponse;
+    }
+
+    private List<ImageResponse> getImagesByAuctionId(Long auctionId) {
+        return jpaQueryFactory
+                .select(new QImageResponse(imageV2.id, imageV2.cdnPath))
+                .from(imageV2)
+                .where(imageV2.auction.id.eq(auctionId))
+                .orderBy(imageV2.sequence.asc())
+                .fetch();
+    }
+
+    private BooleanExpression isAuctionLikedByUserId(Long userId) {
+        return JPAExpressions.selectOne()
+                .from(likeV2)
+                .where(likeV2.auctionId.eq(auctionV2.id)
+                        .and(likeUserIdEq(userId)))
+                .exists();
+    }
+
     private BooleanExpression isRepresentativeImage() {
         return imageV2.auction.eq(auctionV2).and(imageV2.sequence.eq(1));
     }
 
+    private BooleanBuilder userIdEq(Long userId) {
+        return nullSafeBuilder(() -> user.id.eq(userId));
+    }
+
+    private BooleanBuilder bidderIdEqSub(QBid qBid, Long userId) {
+        return nullSafeBuilder(() -> qBid.bidderId.eq(userId));
+    }
+
+    private BooleanBuilder winnerIdEq(Long userId) {
+        return nullSafeBuilder(() -> auctionV2.winnerId.isNotNull().and(auctionV2.winnerId.eq(userId)));
+    }
+
+    private BooleanBuilder likeUserIdEq(Long userId) {
+        return nullSafeBuilder(() -> likeV2.userId.eq(userId));
+    }
+
+    private static NumberExpression<Integer> timeRemaining() {
+        return numberTemplate(Integer.class,
+                "GREATEST(0, TIMESTAMPDIFF(SECOND, CURRENT_TIMESTAMP, {0}))", auctionV2.endDateTime); // 음수면 0으로 처리
+    }
 }

--- a/src/main/java/org/chzz/market/domain/auctionv2/repository/AuctionV2Repository.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/repository/AuctionV2Repository.java
@@ -1,8 +1,13 @@
 package org.chzz.market.domain.auctionv2.repository;
 
+import java.util.Optional;
 import org.chzz.market.domain.auction.repository.AuctionRepositoryCustom;
+import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
 import org.chzz.market.domain.auctionv2.entity.AuctionV2;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface AuctionV2Repository extends JpaRepository<AuctionV2, Long>, AuctionRepositoryCustom {
+    @Query("SELECT a.status FROM AuctionV2 a WHERE a.id = :auctionId")
+    Optional<AuctionStatus> findAuctionStatusById(Long auctionId);
 }

--- a/src/main/java/org/chzz/market/domain/auctionv2/service/AuctionDetailService.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/service/AuctionDetailService.java
@@ -1,0 +1,37 @@
+package org.chzz.market.domain.auctionv2.service;
+
+import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.AUCTION_NOT_FOUND;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.chzz.market.domain.auctionv2.dto.response.AuctionDetailBaseResponse;
+import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
+import org.chzz.market.domain.auctionv2.error.AuctionException;
+import org.chzz.market.domain.auctionv2.repository.AuctionV2QueryRepository;
+import org.chzz.market.domain.auctionv2.repository.AuctionV2Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuctionDetailService {
+    private final AuctionV2Repository auctionRepository;
+    private final AuctionV2QueryRepository auctionQueryRepository;
+
+    public AuctionDetailBaseResponse getAuctionDetails(Long userId, Long auctionId) {
+        return auctionRepository.findAuctionStatusById(auctionId)
+                .flatMap(status -> getAuctionDetailByStatus(status, userId, auctionId))
+                .orElseThrow(() -> new AuctionException(AUCTION_NOT_FOUND));
+    }
+
+    private Optional<AuctionDetailBaseResponse> getAuctionDetailByStatus(AuctionStatus status, Long userId,
+                                                                         Long auctionId) {
+        return switch (status) {
+            case PRE -> auctionQueryRepository.findPreAuctionDetailById(userId, auctionId)
+                    .map(response -> response);
+            case PROCEEDING, ENDED -> auctionQueryRepository.findOfficialAuctionDetailById(userId, auctionId)
+                    .map(response -> response.clearOrderIfNotEligible());
+        };
+    }
+}

--- a/src/main/java/org/chzz/market/domain/orderv2/entity/OrderV2.java
+++ b/src/main/java/org/chzz/market/domain/orderv2/entity/OrderV2.java
@@ -17,7 +17,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.chzz.market.domain.auctionv2.entity.AuctionV2;
-import org.chzz.market.domain.payment.entity.Payment.PaymentMethod;
+import org.chzz.market.domain.paymentv2.entity.PaymentV2.PaymentMethod;
 
 @Entity
 @Getter

--- a/src/main/java/org/chzz/market/domain/orderv2/entity/OrderV2.java
+++ b/src/main/java/org/chzz/market/domain/orderv2/entity/OrderV2.java
@@ -1,0 +1,74 @@
+package org.chzz.market.domain.orderv2.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.chzz.market.domain.auctionv2.entity.AuctionV2;
+import org.chzz.market.domain.payment.entity.Payment.PaymentMethod;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "orders_v2")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class OrderV2 {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String orderNo;
+
+    @Column(nullable = false)
+    private Long buyerId;
+
+    @Column(nullable = false)
+    private Long paymentId;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column
+    private String deliveryMemo;
+
+    @Column(nullable = false)
+    private String roadAddress;
+
+    @Column(nullable = false)
+    private String jibun;
+
+    @Column(nullable = false)
+    private String zipcode;
+
+    @Column(nullable = false)
+    private String detailAddress;
+
+    @Column(nullable = false)
+    private String recipientName;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @Column(columnDefinition = "varchar(30)", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod method;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "auction_id")
+    private AuctionV2 auction;
+}

--- a/src/main/java/org/chzz/market/domain/orderv2/repository/OrderV2Repository.java
+++ b/src/main/java/org/chzz/market/domain/orderv2/repository/OrderV2Repository.java
@@ -1,0 +1,7 @@
+package org.chzz.market.domain.orderv2.repository;
+
+import org.chzz.market.domain.orderv2.entity.OrderV2;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderV2Repository extends JpaRepository<OrderV2, Long> {
+}

--- a/src/main/java/org/chzz/market/domain/paymentv2/entity/PaymentV2.java
+++ b/src/main/java/org/chzz/market/domain/paymentv2/entity/PaymentV2.java
@@ -13,11 +13,11 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.chzz.market.domain.auctionv2.entity.AuctionV2;
 import org.chzz.market.domain.base.entity.BaseTimeEntity;
-import org.chzz.market.domain.payment.entity.Payment.PaymentMethod;
 import org.chzz.market.domain.user.entity.User;
 
 @Getter
@@ -60,5 +60,20 @@ public class PaymentV2 extends BaseTimeEntity {
         if (this.status == null) {
             this.status = Status.READY;
         }
+    }
+
+    @AllArgsConstructor
+    public enum PaymentMethod {
+        CARD("카드"),
+        VIRTUAL_ACCOUNT("가상계좌"),
+        EASY_PAYMENT("간편결제"),
+        MOBILE("휴대폰"),
+        ACCOUNT_TRANSFER("계좌이체"),
+        CULTURE_GIFT_CARD("문화상품권"),
+        BOOK_CULTURE_GIFT_CARD("도서문화상품권"),
+        GAME_CULTURE_GIFT_CARD("게임문화상품권"),
+        CASH("테스트용");
+
+        private final String description;
     }
 }

--- a/src/main/java/org/chzz/market/domain/paymentv2/entity/PaymentV2.java
+++ b/src/main/java/org/chzz/market/domain/paymentv2/entity/PaymentV2.java
@@ -1,0 +1,64 @@
+package org.chzz.market.domain.paymentv2.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.chzz.market.domain.auctionv2.entity.AuctionV2;
+import org.chzz.market.domain.base.entity.BaseTimeEntity;
+import org.chzz.market.domain.payment.entity.Payment.PaymentMethod;
+import org.chzz.market.domain.user.entity.User;
+
+@Getter
+@Entity
+@Table
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentV2 extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User payer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "auction_id", nullable = false)
+    private AuctionV2 auction;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(columnDefinition = "varchar(30)", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod method;
+
+    @Column(columnDefinition = "varchar(30)", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @Column(unique = true, nullable = false)
+    private String orderNo;
+
+    @Column(nullable = false)
+    private String paymentKey;
+
+    @PrePersist
+    protected void onPrePersist() {
+        if (this.status == null) {
+            this.status = Status.READY;
+        }
+    }
+}

--- a/src/main/java/org/chzz/market/domain/paymentv2/entity/Status.java
+++ b/src/main/java/org/chzz/market/domain/paymentv2/entity/Status.java
@@ -1,0 +1,12 @@
+package org.chzz.market.domain.paymentv2.entity;
+
+public enum Status {
+    READY,
+    IN_PROGRESS,
+    WAITING_FOR_DEPOSIT,
+    DONE,
+    CANCELED,
+    PARTIAL_CANCELED,
+    ABORTED,
+    EXPIRED
+}

--- a/src/main/java/org/chzz/market/domain/paymentv2/respository/PaymentV2Repository.java
+++ b/src/main/java/org/chzz/market/domain/paymentv2/respository/PaymentV2Repository.java
@@ -1,0 +1,7 @@
+package org.chzz.market.domain.paymentv2.respository;
+
+import org.chzz.market.domain.paymentv2.entity.PaymentV2;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentV2Repository extends JpaRepository<PaymentV2, Long> {
+}

--- a/src/main/resources/db/migration/V16__create_v2_order_payment.sql
+++ b/src/main/resources/db/migration/V16__create_v2_order_payment.sql
@@ -1,0 +1,55 @@
+-- 파일명: V16__create_v2_order_payment.sql
+-- 파일 설명: v2 order, payment, 경매 API 전환완료시 삭제 예정
+-- 작성일: 2024-11-18
+-- 참고: 이 파일은 Flyway 명명 규칙 "V<버전번호>__<설명>.sql"을 따릅니다.
+--      적용된 후에는 절대 수정할 수 없으므로, 수정이 필요한 경우에는 새로운 마이그레이션 파일을 작성해 주세요.
+
+CREATE TABLE orders_v2
+(
+    order_id       BIGINT AUTO_INCREMENT NOT NULL,
+    order_no       VARCHAR(255)          NOT NULL,
+    buyer_id       BIGINT                NOT NULL,
+    payment_id     BIGINT                NOT NULL,
+    amount         BIGINT                NOT NULL,
+    delivery_memo  VARCHAR(255)          NULL,
+    road_address   VARCHAR(255)          NOT NULL,
+    jibun          VARCHAR(255)          NOT NULL,
+    zipcode        VARCHAR(255)          NOT NULL,
+    detail_address VARCHAR(255)          NOT NULL,
+    recipient_name VARCHAR(255)          NOT NULL,
+    phone_number   VARCHAR(255)          NOT NULL,
+    method         VARCHAR(30)           NOT NULL,
+    auction_id     BIGINT                NULL,
+    CONSTRAINT pk_orders_v2 PRIMARY KEY (order_id)
+);
+
+CREATE TABLE paymentv2
+(
+    payment_id  BIGINT AUTO_INCREMENT NOT NULL,
+    created_at  datetime              NULL,
+    updated_at  datetime              NULL,
+    user_id     BIGINT                NOT NULL,
+    auction_id  BIGINT                NOT NULL,
+    amount      BIGINT                NOT NULL,
+    method      VARCHAR(30)           NOT NULL,
+    status      VARCHAR(30)           NOT NULL,
+    order_no    VARCHAR(255)          NOT NULL,
+    payment_key VARCHAR(255)          NOT NULL,
+    CONSTRAINT pk_paymentv2 PRIMARY KEY (payment_id)
+);
+
+ALTER TABLE paymentv2
+    ADD CONSTRAINT uc_paymentv2_orderno UNIQUE (order_no);
+
+ALTER TABLE orders_v2
+    ADD CONSTRAINT FK_ORDERS_V2_ON_AUCTION FOREIGN KEY (auction_id) REFERENCES auction_v2 (auction_id);
+
+ALTER TABLE paymentv2
+    ADD CONSTRAINT FK_PAYMENTV2_ON_AUCTION FOREIGN KEY (auction_id) REFERENCES auction_v2 (auction_id);
+
+ALTER TABLE paymentv2
+    ADD CONSTRAINT FK_PAYMENTV2_ON_USER FOREIGN KEY (user_id) REFERENCES users (user_id);
+
+ALTER TABLE auction_v2
+    MODIFY COLUMN bid_count BIGINT NULL,
+    MODIFY COLUMN like_count BIGINT NULL;

--- a/src/test/java/org/chzz/market/domain/auctionv2/repository/AuctionV2QueryRepositoryTest.java
+++ b/src/test/java/org/chzz/market/domain/auctionv2/repository/AuctionV2QueryRepositoryTest.java
@@ -2,8 +2,8 @@ package org.chzz.market.domain.auctionv2.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
 import java.util.Optional;
+import org.chzz.market.domain.auctionv2.dto.response.OfficialAuctionDetailResponse;
 import org.chzz.market.domain.auctionv2.dto.response.WonAuctionDetailsResponse;
 import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
 import org.chzz.market.domain.auctionv2.entity.AuctionV2;
@@ -11,9 +11,14 @@ import org.chzz.market.domain.auctionv2.entity.Category;
 import org.chzz.market.domain.bid.entity.Bid;
 import org.chzz.market.domain.bid.repository.BidRepository;
 import org.chzz.market.domain.image.entity.ImageV2;
+import org.chzz.market.domain.orderv2.entity.OrderV2;
+import org.chzz.market.domain.orderv2.repository.OrderV2Repository;
+import org.chzz.market.domain.paymentv2.entity.PaymentV2.PaymentMethod;
 import org.chzz.market.domain.user.entity.User;
-import org.chzz.market.domain.user.entity.User.ProviderType;
 import org.chzz.market.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,27 +35,200 @@ class AuctionV2QueryRepositoryTest {
     private BidRepository bidRepository;
     @Autowired
     private UserRepository userRepository;
+    @Autowired
+    private OrderV2Repository orderRepository;
+
+    private User seller;
+    private User user;
+    private ImageV2 defaultImage;
+
+    @BeforeEach
+    void setUp() {
+        seller = User.builder().email("seller").providerId("seller").providerType(User.ProviderType.KAKAO).build();
+        user = User.builder().email("user").providerId("user").providerType(User.ProviderType.KAKAO).build();
+        defaultImage = ImageV2.builder().cdnPath("https://cdn.com").sequence(1).build();
+
+        userRepository.save(seller);
+        userRepository.save(user);
+    }
+
+    private AuctionV2 createAuction(User seller, String name, String description, AuctionStatus status, Long winnerId) {
+        AuctionV2 auction = AuctionV2.builder()
+                .seller(seller)
+                .name(name)
+                .description(description)
+                .status(status)
+                .category(Category.ELECTRONICS)
+                .winnerId(winnerId)
+                .build();
+        auction.addImage(defaultImage);
+        auctionV2Repository.save(auction);
+        return auction;
+    }
+
+    private Bid createBid(User bidder, AuctionV2 auction, Long amount, Bid.BidStatus status) {
+        Bid bid = Bid.builder()
+                .bidderId(bidder.getId())
+                .auctionId(auction.getId())
+                .amount(amount)
+                .status(status)
+                .build();
+        bidRepository.save(bid);
+        return bid;
+    }
+
+    private OrderV2 createOrder(AuctionV2 auction, User buyer, Long amount) {
+        OrderV2 order = OrderV2.builder()
+                .auction(auction)
+                .buyerId(buyer.getId())
+                .amount(amount)
+                .paymentId(1L)
+                .roadAddress("서울시 강남구")
+                .jibun("123")
+                .zipcode("123")
+                .detailAddress("123")
+                .recipientName("홍길동")
+                .phoneNumber("01012345678")
+                .method(PaymentMethod.CARD)
+                .orderNo("123")
+                .build();
+        orderRepository.save(order);
+        return order;
+    }
 
     @Test
     void 낙찰정보를_조회한다() {
-        // given
-        ImageV2 imageV2 = ImageV2.builder().cdnPath("https://cdn.com").sequence(1).build();
+        // Given
+        AuctionV2 auction = createAuction(seller, "맥북프로", "맥북프로 2019년형 팝니다.", AuctionStatus.PROCEEDING, user.getId());
+        createBid(user, auction, 2000L, Bid.BidStatus.ACTIVE);
 
-        User user = User.builder().email("ex").providerId("ex").providerType(ProviderType.KAKAO).build();
-        userRepository.save(user);
-        AuctionV2 auction = AuctionV2.builder().seller(user).name("맥북프로").description("맥북프로 2019년형 팝니다.")
-                .status(AuctionStatus.PROCEEDING).category(Category.ELECTRONICS).winnerId(1L).build();
-        auction.addImage(imageV2);
-        Bid bid1 = Bid.builder().bidderId(1L).auctionId(1L).amount(2000L).build();
-        Bid bid2 = Bid.builder().bidderId(2L).auctionId(1L).amount(1000L).build();
-        auctionV2Repository.save(auction);
-        bidRepository.saveAll(List.of(bid1, bid2));
-        // when
-        Optional<WonAuctionDetailsResponse> result = auctionQueryRepository.findWinningBidById(1L);
+        // When
+        Optional<WonAuctionDetailsResponse> result = auctionQueryRepository.findWinningBidById(auction.getId());
 
-        // then
+        // Then
         assertThat(result).isPresent();
         assertThat(result.get().winningAmount()).isEqualTo(2000L);
     }
 
+    @Nested
+    @DisplayName("정식 경매 상세정보조회")
+    class OfficialAuctionDetail {
+        @Test
+        void 본인의_제품을_조회한경우() {
+            // Given
+            AuctionV2 auction = createAuction(seller, "맥북프로", "맥북프로 2019년형 팝니다.", AuctionStatus.ENDED, seller.getId());
+
+            // When
+            Optional<OfficialAuctionDetailResponse> result = auctionQueryRepository.findOfficialAuctionDetailById(
+                    seller.getId(), auction.getId());
+
+            // Then
+            OfficialAuctionDetailResponse response = result.get();
+            assertThat(response).isNotNull();
+            assertThat(response.getIsSeller()).isTrue();
+            assertThat(response.getIsParticipated()).isFalse();
+            assertThat(response.getIsWon()).isTrue();
+            assertThat(response.getIsOrdered()).isFalse();
+        }
+
+        @Test
+        void 다른_사람_경매를_참여안한경우_조회한경우() {
+            // Given
+            AuctionV2 auction = createAuction(seller, "맥북프로", "맥북프로 2019년형 팝니다.", AuctionStatus.PROCEEDING, null);
+
+            // When
+            Optional<OfficialAuctionDetailResponse> result = auctionQueryRepository.findOfficialAuctionDetailById(
+                    user.getId(), auction.getId());
+
+            // Then
+            OfficialAuctionDetailResponse response = result.get();
+            assertThat(response).isNotNull();
+            assertThat(response.getIsSeller()).isFalse();
+            assertThat(response.getIsParticipated()).isFalse();
+        }
+
+        @Test
+        void 다른_사람_경매을_참여한경우_조회() {
+            // Given
+            AuctionV2 auction = createAuction(seller, "맥북프로", "맥북프로 2019년형 팝니다.", AuctionStatus.PROCEEDING, null);
+            createBid(user, auction, 1000L, Bid.BidStatus.ACTIVE);
+
+            // When
+            Optional<OfficialAuctionDetailResponse> result = auctionQueryRepository.findOfficialAuctionDetailById(
+                    user.getId(), auction.getId());
+
+            // Then
+            OfficialAuctionDetailResponse response = result.get();
+            assertThat(response).isNotNull();
+            assertThat(response.getIsSeller()).isFalse();
+            assertThat(response.getIsParticipated()).isTrue();
+        }
+
+        @Test
+        void 없는_경매_인경우() {
+            // When
+            Optional<OfficialAuctionDetailResponse> result = auctionQueryRepository.findOfficialAuctionDetailById(
+                    user.getId(), -1L);
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 비로그인_상태에서_조회한_경우() {
+            // Given
+            AuctionV2 auction = createAuction(seller, "맥북프로", "맥북프로 2019년형 팝니다.", AuctionStatus.PROCEEDING, null);
+
+            // When
+            Optional<OfficialAuctionDetailResponse> result = auctionQueryRepository.findOfficialAuctionDetailById(
+                    null, auction.getId());
+
+            // Then
+            OfficialAuctionDetailResponse response = result.get();
+            assertThat(response).isNotNull();
+            assertThat(response.getIsSeller()).isFalse();
+            assertThat(response.getIsParticipated()).isFalse();
+            assertThat(response.getBidId()).isNull();
+            assertThat(response.getBidAmount()).isEqualTo(0L);
+            assertThat(response.getRemainingBidCount()).isEqualTo(3);
+        }
+
+        @Test
+        void 취소된_입찰이_있는_경우() {
+            // Given
+            AuctionV2 auction = createAuction(seller, "맥북프로", "맥북프로 2019년형 팝니다.", AuctionStatus.PROCEEDING, null);
+            createBid(user, auction, 2000L, Bid.BidStatus.CANCELLED);
+
+            // When
+            Optional<OfficialAuctionDetailResponse> result = auctionQueryRepository.findOfficialAuctionDetailById(
+                    user.getId(), auction.getId());
+
+            // Then
+            OfficialAuctionDetailResponse response = result.get();
+            assertThat(response).isNotNull();
+            assertThat(response.getIsCancelled()).isTrue();
+        }
+
+        @Test
+        void 주문이_있을시_조회를_한다() {
+            // Given
+            AuctionV2 auction = createAuction(seller, "맥북프로", "맥북프로 2019년형 팝니다.", AuctionStatus.PROCEEDING,
+                    user.getId());
+            createBid(user, auction, 2000L, Bid.BidStatus.ACTIVE);
+            createOrder(auction, user, 2000L);
+
+            // When
+            Optional<OfficialAuctionDetailResponse> result = auctionQueryRepository.findOfficialAuctionDetailById(
+                    user.getId(), auction.getId());
+
+            // Then
+            OfficialAuctionDetailResponse response = result.get();
+            assertThat(response).isNotNull();
+            assertThat(response.getIsSeller()).isFalse();
+            assertThat(response.getIsParticipated()).isTrue();
+            assertThat(response.getIsWon()).isTrue();
+            assertThat(response.getIsWinner()).isTrue();
+            assertThat(response.getIsOrdered()).isTrue();
+        }
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-이슈번호]

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
요청받은 경매의 status에 따라, 정식경매 응답, 사전경매 응답 분기하였습니다

- [x]  경매 상세 조회(정식경매과 사전경매)

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->
![스크린샷 2024-11-18 오후 11 24 47](https://github.com/user-attachments/assets/7e8954e4-3fd3-49de-8784-a022313b72ac)