### PR TITLE
refactor: 입찰 API, 좋아요 API 전환

### DIFF
--- a/.github/workflows/pr_review_reminder.yml
+++ b/.github/workflows/pr_review_reminder.yml
@@ -63,7 +63,6 @@ jobs:
         run: |
           reviewer_map='[
             {"github": "junest66", "discord": "<@444811214623735839>"},
-            {"github": "viaunixue", "discord": "<@386917108455309316>"},
             {"github": "YeaChan05", "discord": "<@391487793995579403>"}
           ]'
           prs=$(cat prs.json)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ border-radius: 20px;" >
 
 </br>
 
-[✨ <치즈마켓> 사용해보기](https://chzzmarket.vercel.app/)
+[✨ <치즈마켓> 사용해보기](https://chzzmarket.store/)
 
 [//]: # ([📄 API 문서 바로가기]&#40;https://app.swaggerhub.com/apis-docs/CHLWNDKS333_1/chzz-market-api/1.0.0#/Products&#41;)
 

--- a/src/main/java/org/chzz/market/common/aop/redisrock/DistributedLockAop.java
+++ b/src/main/java/org/chzz/market/common/aop/redisrock/DistributedLockAop.java
@@ -24,7 +24,7 @@ public class DistributedLockAop {
     private final RedissonClient redissonClient;
     private final AopForTransaction aopForTransaction;
 
-    @Around("@annotation(org.chzz.market.common.aop.redisrock.DistributedLock)")
+    @Around("@annotation(DistributedLock)")
     public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();

--- a/src/main/java/org/chzz/market/common/aop/redisrock/DistributedLockAop.java
+++ b/src/main/java/org/chzz/market/common/aop/redisrock/DistributedLockAop.java
@@ -34,28 +34,27 @@ public class DistributedLockAop {
                 joinPoint.getArgs(), distributedLock.key());
         RLock rLock = redissonClient.getLock(key);  // (1) 락의 이름으로 RLock 인스턴스를 가져옴
 
-        log.info("Lock 획득 시도 중... [method: {}]", method.getName());
+        log.debug("Lock 획득 시도 중... [method: {}, key: {}]", method.getName(), key);
 
         try {
             boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(),
                     distributedLock.timeUnit());  // (2) 정의된 waitTime까지 획득을 시도, 정의된 leaseTime이 지나면 잠금을 해제
             if (!available) {
-                log.warn("Lock 획득 실패 [method: {}]", method.getName());
+                log.warn("Lock 획득 실패 [method: {}, key: {}]", method.getName(), key);
                 return false;
             }
-            log.info("Lock 획득 성공 [method: {}]", method.getName());
+            log.debug("Lock 획득 성공 [method: {}, key: {}]", method.getName(), key);
 
             return aopForTransaction.proceed(joinPoint);  // (3) DistributedLock 어노테이션이 선언된 메서드를 별도의 트랜잭션으로 실행
         } catch (InterruptedException e) {
-            log.error("Lock 획득 중 인터럽트가 발생 [method: {}]", method.getName(), e);
+            log.error("Lock 획득 중 인터럽트가 발생 [method: {}, key: {}]", method.getName(), key, e);
             throw new InterruptedException();
         } finally {
             try {
                 rLock.unlock();   // (4) 종료 시 무조건 락을 해제
-                log.info("Lock 해제 [method: {}]", method.getName());
-
+                log.debug("Lock 해제 [method: {}, key: {}]", method.getName(), key);
             } catch (IllegalMonitorStateException e) {
-                log.warn("이미 Lock 해제 [method: {}]", method.getName());
+                log.warn("이미 Lock 해제 [method: {}, key: {}]", method.getName(), key);
             }
         }
     }

--- a/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailApi.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailApi.java
@@ -83,6 +83,11 @@ public interface AuctionDetailApi {
                                       @PathVariable Long auctionId);
 
     @Operation(summary = "특정 경매 좋아요(찜) 요청 및 취소", description = "특정 경매에 대한 좋아요(찜) 요청 및 취소를 합니다.")
+    @ApiResponseExplanations(
+            errors = {
+                    @ApiExceptionExplanation(value = AuctionErrorCode.class, constant = AUCTION_NOT_FOUND, name = "경매를 찾을 수 없는 경우"),
+            }
+    )
     ResponseEntity<Void> likeAuction(@LoginUser Long userId,
                                      @PathVariable Long auctionId);
 

--- a/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailApi.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailApi.java
@@ -25,7 +25,6 @@ import org.chzz.market.domain.auctionv2.dto.response.WonAuctionDetailsResponse;
 import org.chzz.market.domain.auctionv2.error.AuctionErrorCode;
 import org.chzz.market.domain.bid.dto.response.BidInfoResponse;
 import org.chzz.market.domain.imagev2.error.ImageErrorCode;
-import org.chzz.market.domain.like.dto.LikeResponse;
 import org.chzz.market.domain.product.dto.UpdateProductRequest;
 import org.chzz.market.domain.product.dto.UpdateProductResponse;
 import org.springdoc.core.annotations.ParameterObject;
@@ -84,8 +83,8 @@ public interface AuctionDetailApi {
                                       @PathVariable Long auctionId);
 
     @Operation(summary = "특정 경매 좋아요(찜) 요청 및 취소", description = "특정 경매에 대한 좋아요(찜) 요청 및 취소를 합니다.")
-    ResponseEntity<LikeResponse> likeAuction(@LoginUser Long userId,
-                                             @PathVariable Long auctionId);
+    ResponseEntity<Void> likeAuction(@LoginUser Long userId,
+                                     @PathVariable Long auctionId);
 
     @Operation(summary = "특정 경매 수정", description = "특정 경매를 수정합니다.")
     ResponseEntity<UpdateProductResponse> updateAuction(@LoginUser Long userId,

--- a/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailController.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/controller/AuctionDetailController.java
@@ -12,7 +12,7 @@ import org.chzz.market.domain.auctionv2.service.AuctionStartService;
 import org.chzz.market.domain.auctionv2.service.AuctionWonService;
 import org.chzz.market.domain.bid.dto.response.BidInfoResponse;
 import org.chzz.market.domain.bid.service.BidLookupService;
-import org.chzz.market.domain.like.dto.LikeResponse;
+import org.chzz.market.domain.likev2.service.LikeUpdateService;
 import org.chzz.market.domain.product.dto.UpdateProductRequest;
 import org.chzz.market.domain.product.dto.UpdateProductResponse;
 import org.springframework.data.domain.Page;
@@ -38,6 +38,7 @@ public class AuctionDetailController implements AuctionDetailApi {
     private final AuctionStartService auctionStartService;
     private final AuctionWonService auctionWonService;
     private final BidLookupService bidLookupService;
+    private final LikeUpdateService likeUpdateService;
 
     @Override
     @GetMapping
@@ -63,15 +64,17 @@ public class AuctionDetailController implements AuctionDetailApi {
 
     @Override
     @PostMapping("/start")
-    public ResponseEntity<Void> startAuction(Long userId, Long auctionId) {
+    public ResponseEntity<Void> startAuction(@LoginUser Long userId,
+                                             @PathVariable Long auctionId) {
         auctionStartService.start(userId, auctionId);
         return ResponseEntity.ok().build();
     }
 
     @Override
     @PostMapping("/likes")
-    public ResponseEntity<LikeResponse> likeAuction(Long userId, Long auctionId) {
-        return null;
+    public ResponseEntity<Void> likeAuction(@LoginUser Long userId, @PathVariable Long auctionId) {
+        likeUpdateService.updateLike(userId, auctionId);
+        return ResponseEntity.ok().build();
     }
 
     @Override

--- a/src/main/java/org/chzz/market/domain/auctionv2/error/AuctionErrorCode.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/error/AuctionErrorCode.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 public enum AuctionErrorCode implements ErrorCode {
     AUCTION_NOT_ENDED(BAD_REQUEST, "해당 경매가 아직 끝나지 않았습니다."),
     AUCTION_ALREADY_OFFICIAL(BAD_REQUEST, "해당 경매는 이미 정식 경매입니다."),
+    AUCTION_ENDED(BAD_REQUEST, "해당 경매가 진행 중이 아니거나 이미 종료되었습니다."),
     OFFICIAL_AUCTION_DELETE_FORBIDDEN(FORBIDDEN, "정식경매는 삭제할수 없습니다."),
     NOW_WINNER(FORBIDDEN, "낙찰자가 아닙니다."),
     AUCTION_ACCESS_FORBIDDEN(FORBIDDEN, "해당 경매에 접근할 수 없습니다."),
@@ -25,6 +26,7 @@ public enum AuctionErrorCode implements ErrorCode {
     public static class Const {
         public static final String AUCTION_NOT_ENDED = "AUCTION_NOT_ENDED";
         public static final String AUCTION_ALREADY_OFFICIAL = "AUCTION_ALREADY_OFFICIAL";
+        public static final String AUCTION_ENDED = "AUCTION_ENDED";
         public static final String OFFICIAL_AUCTION_DELETE_FORBIDDEN = "OFFICIAL_AUCTION_DELETE_FORBIDDEN";
         public static final String NOW_WINNER = "NOW_WINNER";
         public static final String AUCTION_ACCESS_FORBIDDEN = "AUCTION_ACCESS_FORBIDDEN";

--- a/src/main/java/org/chzz/market/domain/auctionv2/repository/AuctionV2Repository.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/repository/AuctionV2Repository.java
@@ -5,9 +5,18 @@ import org.chzz.market.domain.auction.repository.AuctionRepositoryCustom;
 import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
 import org.chzz.market.domain.auctionv2.entity.AuctionV2;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface AuctionV2Repository extends JpaRepository<AuctionV2, Long>, AuctionRepositoryCustom {
     @Query("SELECT a.status FROM AuctionV2 a WHERE a.id = :auctionId")
     Optional<AuctionStatus> findAuctionStatusById(Long auctionId);
+
+    @Modifying
+    @Query("UPDATE AuctionV2 a SET a.likeCount = a.likeCount + 1 WHERE a.id = :auctionId")
+    void incrementLikeCount(Long auctionId);
+
+    @Modifying
+    @Query("UPDATE AuctionV2 a SET a.likeCount = a.likeCount - 1 WHERE a.id = :auctionId")
+    void decrementLikeCount(Long auctionId);
 }

--- a/src/main/java/org/chzz/market/domain/auctionv2/repository/AuctionV2Repository.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/repository/AuctionV2Repository.java
@@ -17,7 +17,7 @@ public interface AuctionV2Repository extends JpaRepository<AuctionV2, Long>, Auc
     void incrementLikeCount(Long auctionId);
 
     @Modifying
-    @Query("UPDATE AuctionV2 a SET a.likeCount = a.likeCount - 1 WHERE a.id = :auctionId")
+    @Query("UPDATE AuctionV2 a SET a.likeCount = a.likeCount - 1 WHERE a.id = :auctionId AND a.likeCount > 0")
     void decrementLikeCount(Long auctionId);
 
     @Modifying
@@ -25,6 +25,6 @@ public interface AuctionV2Repository extends JpaRepository<AuctionV2, Long>, Auc
     void incrementBidCount(Long auctionId);
 
     @Modifying
-    @Query("UPDATE AuctionV2 a SET a.bidCount = a.bidCount - 1 WHERE a.id = :auctionId")
+    @Query("UPDATE AuctionV2 a SET a.bidCount = a.bidCount - 1 WHERE a.id = :auctionId AND a.bidCount > 0")
     void decrementBidCount(Long auctionId);
 }

--- a/src/main/java/org/chzz/market/domain/auctionv2/repository/AuctionV2Repository.java
+++ b/src/main/java/org/chzz/market/domain/auctionv2/repository/AuctionV2Repository.java
@@ -19,4 +19,12 @@ public interface AuctionV2Repository extends JpaRepository<AuctionV2, Long>, Auc
     @Modifying
     @Query("UPDATE AuctionV2 a SET a.likeCount = a.likeCount - 1 WHERE a.id = :auctionId")
     void decrementLikeCount(Long auctionId);
+
+    @Modifying
+    @Query("UPDATE AuctionV2 a SET a.bidCount = a.bidCount + 1 WHERE a.id = :auctionId")
+    void incrementBidCount(Long auctionId);
+
+    @Modifying
+    @Query("UPDATE AuctionV2 a SET a.bidCount = a.bidCount - 1 WHERE a.id = :auctionId")
+    void decrementBidCount(Long auctionId);
 }

--- a/src/main/java/org/chzz/market/domain/bid/controller/BidApi.java
+++ b/src/main/java/org/chzz/market/domain/bid/controller/BidApi.java
@@ -1,6 +1,7 @@
 package org.chzz.market.domain.bid.controller;
 
-import static org.chzz.market.domain.auction.error.AuctionErrorCode.Const.AUCTION_ENDED;
+import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.Const.AUCTION_ENDED;
+import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.Const.AUCTION_NOT_FOUND;
 import static org.chzz.market.domain.bid.error.BidErrorCode.Const.BID_ALREADY_CANCELLED;
 import static org.chzz.market.domain.bid.error.BidErrorCode.Const.BID_BELOW_MIN_PRICE;
 import static org.chzz.market.domain.bid.error.BidErrorCode.Const.BID_BY_OWNER;
@@ -11,39 +12,54 @@ import static org.chzz.market.domain.bid.error.BidErrorCode.Const.BID_SAME_AS_PR
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.chzz.market.common.config.LoginUser;
 import org.chzz.market.common.springdoc.ApiExceptionExplanation;
 import org.chzz.market.common.springdoc.ApiResponseExplanations;
-import org.chzz.market.domain.auction.error.AuctionErrorCode;
 import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
+import org.chzz.market.domain.auctionv2.error.AuctionErrorCode;
 import org.chzz.market.domain.bid.dto.BidCreateRequest;
 import org.chzz.market.domain.bid.dto.query.BiddingRecord;
 import org.chzz.market.domain.bid.error.BidErrorCode;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "bids", description = "입찰 API")
 public interface BidApi {
     @Operation(summary = "나의 입찰 목록 조회")
-    ResponseEntity<Page<BiddingRecord>> findUsersBidHistory(Long userId, @ParameterObject Pageable pageable,
-                                                            AuctionStatus status);
+    ResponseEntity<Page<BiddingRecord>> findUsersBidHistory(@LoginUser Long userId,
+                                                            @PageableDefault(sort = "time-remaining") @ParameterObject Pageable pageable,
+                                                            @RequestParam(value = "status", required = false) AuctionStatus status);
 
     @Operation(summary = "입찰 요청 및 수정")
     @ApiResponseExplanations(
             errors = {
                     @ApiExceptionExplanation(value = BidErrorCode.class, constant = BID_LIMIT_EXCEEDED, name = "입찰 횟수 제한을 초과 했을때"),
-                    @ApiExceptionExplanation(value = AuctionErrorCode.class, constant = AUCTION_ENDED, name = "경매가 종료된 경우"),
+                    @ApiExceptionExplanation(value = AuctionErrorCode.class, constant = AUCTION_ENDED, name = "해당 경매가 진행 중이 아니거나 이미 종료되었습니다."),
                     @ApiExceptionExplanation(value = BidErrorCode.class, constant = BID_SAME_AS_PREVIOUS, name = "이전 입찰금액과 동일한 경우"),
                     @ApiExceptionExplanation(value = BidErrorCode.class, constant = BID_BELOW_MIN_PRICE, name = "입찰금액이 최소가보다 낮은 경우"),
                     @ApiExceptionExplanation(value = BidErrorCode.class, constant = BID_BY_OWNER, name = "경매 등록자가 입찰 할때"),
-                    @ApiExceptionExplanation(value = BidErrorCode.class, constant = BID_NOT_FOUND, name = "없는 경매 일때"),
-                    @ApiExceptionExplanation(value = BidErrorCode.class, constant = BID_NOT_FOUND, name = "없는 경매 일때"),
+                    @ApiExceptionExplanation(value = BidErrorCode.class, constant = BID_NOT_FOUND, name = "없는 입찰 일때"),
+                    @ApiExceptionExplanation(value = AuctionErrorCode.class, constant = AUCTION_NOT_FOUND, name = "없는 경매 일때"),
                     @ApiExceptionExplanation(value = BidErrorCode.class, constant = BID_ALREADY_CANCELLED, name = "취소한 입찰 일때"),
             }
     )
-    ResponseEntity<Void> createBid(@Valid BidCreateRequest bidCreateRequest, Long userId);
+    ResponseEntity<Void> createBid(@Valid @RequestBody BidCreateRequest bidCreateRequest,
+                                   @LoginUser Long userId);
 
     @Operation(summary = "입찰 취소")
+    @ApiResponseExplanations(
+            errors = {
+                    @ApiExceptionExplanation(value = AuctionErrorCode.class, constant = AUCTION_ENDED, name = "해당 경매가 진행 중이 아니거나 이미 종료되었습니다."),
+                    @ApiExceptionExplanation(value = BidErrorCode.class, constant = BID_BY_OWNER, name = "경매 등록자가 입찰취소 할때"),
+                    @ApiExceptionExplanation(value = BidErrorCode.class, constant = BID_NOT_FOUND, name = "없는 입찰 일때"),
+                    @ApiExceptionExplanation(value = AuctionErrorCode.class, constant = AUCTION_NOT_FOUND, name = "없는 경매 일때"),
+                    @ApiExceptionExplanation(value = BidErrorCode.class, constant = BID_ALREADY_CANCELLED, name = "취소한 입찰 일때"),
+            }
+    )
     ResponseEntity<Void> cancelBid(Long bidId, Long userId);
 }

--- a/src/main/java/org/chzz/market/domain/bid/controller/BidApi.java
+++ b/src/main/java/org/chzz/market/domain/bid/controller/BidApi.java
@@ -14,7 +14,7 @@ import jakarta.validation.Valid;
 import org.chzz.market.common.springdoc.ApiExceptionExplanation;
 import org.chzz.market.common.springdoc.ApiResponseExplanations;
 import org.chzz.market.domain.auction.error.AuctionErrorCode;
-import org.chzz.market.domain.auction.type.AuctionStatus;
+import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
 import org.chzz.market.domain.bid.dto.BidCreateRequest;
 import org.chzz.market.domain.bid.dto.query.BiddingRecord;
 import org.chzz.market.domain.bid.error.BidErrorCode;

--- a/src/main/java/org/chzz/market/domain/bid/controller/BidController.java
+++ b/src/main/java/org/chzz/market/domain/bid/controller/BidController.java
@@ -5,9 +5,10 @@ import static org.springframework.http.HttpStatus.CREATED;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.chzz.market.common.config.LoginUser;
-import org.chzz.market.domain.auction.type.AuctionStatus;
+import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
 import org.chzz.market.domain.bid.dto.BidCreateRequest;
 import org.chzz.market.domain.bid.dto.query.BiddingRecord;
+import org.chzz.market.domain.bid.service.BidLookupService;
 import org.chzz.market.domain.bid.service.BidService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/v1/bids")
 public class BidController implements BidApi {
+    private final BidLookupService bidLookupService;
     private final BidService bidService;
 
     /**
@@ -42,7 +44,7 @@ public class BidController implements BidApi {
             @LoginUser Long userId,
             @PageableDefault(sort = "time-remaining") Pageable pageable,
             @RequestParam(value = "status", required = false) AuctionStatus status) {
-        Page<BiddingRecord> records = bidService.inquireBidHistory(userId, pageable, status);
+        Page<BiddingRecord> records = bidLookupService.inquireBidHistory(userId, pageable, status);
         return ResponseEntity.ok(records);
     }
 

--- a/src/main/java/org/chzz/market/domain/bid/controller/BidController.java
+++ b/src/main/java/org/chzz/market/domain/bid/controller/BidController.java
@@ -9,7 +9,7 @@ import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
 import org.chzz.market.domain.bid.dto.BidCreateRequest;
 import org.chzz.market.domain.bid.dto.query.BiddingRecord;
 import org.chzz.market.domain.bid.service.BidLookupService;
-import org.chzz.market.domain.bid.service.BidService;
+import org.chzz.market.domain.bid.service.BidUpdateService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/bids")
 public class BidController implements BidApi {
     private final BidLookupService bidLookupService;
-    private final BidService bidService;
+    private final BidUpdateService bidUpdateService;
 
     /**
      * 나의 입찰 목록 조회
@@ -55,7 +55,7 @@ public class BidController implements BidApi {
     @PostMapping
     public ResponseEntity<Void> createBid(@Valid @RequestBody BidCreateRequest bidCreateRequest,
                                           @LoginUser Long userId) {
-        bidService.createBid(bidCreateRequest, userId);
+        bidUpdateService.createBid(bidCreateRequest, userId);
         return ResponseEntity.status(CREATED).build();
     }
 
@@ -66,7 +66,7 @@ public class BidController implements BidApi {
     @PatchMapping("/{bidId}/cancel")
     public ResponseEntity<Void> cancelBid(@PathVariable Long bidId,
                                           @LoginUser Long userId) {
-        bidService.cancelBid(bidId, userId);
+        bidUpdateService.cancelBid(bidId, userId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/chzz/market/domain/bid/controller/BidController.java
+++ b/src/main/java/org/chzz/market/domain/bid/controller/BidController.java
@@ -8,8 +8,9 @@ import org.chzz.market.common.config.LoginUser;
 import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
 import org.chzz.market.domain.bid.dto.BidCreateRequest;
 import org.chzz.market.domain.bid.dto.query.BiddingRecord;
+import org.chzz.market.domain.bid.service.BidCancelService;
+import org.chzz.market.domain.bid.service.BidCreateService;
 import org.chzz.market.domain.bid.service.BidLookupService;
-import org.chzz.market.domain.bid.service.BidUpdateService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -28,7 +29,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/bids")
 public class BidController implements BidApi {
     private final BidLookupService bidLookupService;
-    private final BidUpdateService bidUpdateService;
+    private final BidCreateService bidCreateService;
+    private final BidCancelService bidCancelService;
 
     /**
      * 나의 입찰 목록 조회
@@ -55,7 +57,7 @@ public class BidController implements BidApi {
     @PostMapping
     public ResponseEntity<Void> createBid(@Valid @RequestBody BidCreateRequest bidCreateRequest,
                                           @LoginUser Long userId) {
-        bidUpdateService.createBid(bidCreateRequest, userId);
+        bidCreateService.create(bidCreateRequest, userId);
         return ResponseEntity.status(CREATED).build();
     }
 
@@ -66,7 +68,7 @@ public class BidController implements BidApi {
     @PatchMapping("/{bidId}/cancel")
     public ResponseEntity<Void> cancelBid(@PathVariable Long bidId,
                                           @LoginUser Long userId) {
-        bidUpdateService.cancelBid(bidId, userId);
+        bidCancelService.cancel(bidId, userId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/chzz/market/domain/bid/repository/BidQueryRepository.java
+++ b/src/main/java/org/chzz/market/domain/bid/repository/BidQueryRepository.java
@@ -17,10 +17,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.chzz.market.common.util.QuerydslOrderProvider;
 import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
+import org.chzz.market.domain.auctionv2.entity.AuctionV2;
 import org.chzz.market.domain.bid.dto.query.BiddingRecord;
 import org.chzz.market.domain.bid.dto.query.QBiddingRecord;
 import org.chzz.market.domain.bid.dto.response.BidInfoResponse;
 import org.chzz.market.domain.bid.dto.response.QBidInfoResponse;
+import org.chzz.market.domain.bid.entity.Bid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -60,6 +62,9 @@ public class BidQueryRepository {
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
+    /**
+     * 나의 입찰 목록 조회
+     */
     public Page<BiddingRecord> findUsersBidHistory(Long userId, Pageable pageable, AuctionStatus auctionStatus) {
         // 공통된 부분을 baseQuery로 추출
         JPAQuery<?> baseQuery = jpaQueryFactory
@@ -90,6 +95,17 @@ public class BidQueryRepository {
                 .select(bid.count());
 
         return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
+    }
+
+    /**
+     * 특정 경매의 모든 입찰 Entity 조회
+     */
+    public List<Bid> findAllBidsByAuction(AuctionV2 auction) {
+        return jpaQueryFactory
+                .selectFrom(bid)
+                .where(bid.auctionId.eq(auction.getId()).and(bid.status.eq(ACTIVE)))
+                .orderBy(bid.amount.desc(), bid.updatedAt.asc())
+                .fetch();
     }
 
     private BooleanExpression isRepresentativeImage() {

--- a/src/main/java/org/chzz/market/domain/bid/service/BidCancelLockService.java
+++ b/src/main/java/org/chzz/market/domain/bid/service/BidCancelLockService.java
@@ -1,0 +1,34 @@
+package org.chzz.market.domain.bid.service;
+
+import static org.chzz.market.domain.bid.error.BidErrorCode.BID_NOT_FOUND;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.chzz.market.common.aop.redisrock.DistributedLock;
+import org.chzz.market.domain.auctionv2.repository.AuctionV2Repository;
+import org.chzz.market.domain.bid.entity.Bid;
+import org.chzz.market.domain.bid.error.BidException;
+import org.chzz.market.domain.bid.repository.BidRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BidCancelLockService {
+
+    private final AuctionV2Repository auctionRepository;
+    private final BidRepository bidRepository;
+
+    /**
+     * 분산 락을 사용한 입찰 취소
+     */
+    @Transactional
+    @DistributedLock(key = "'bid:' + #userId + ':' + #auctionId")
+    public void cancel(Long auctionId, Long bidId, Long userId) {
+        Bid bid = bidRepository.findById(bidId).orElseThrow(() -> new BidException(BID_NOT_FOUND));
+        bid.cancelBid();
+        auctionRepository.decrementBidCount(auctionId);
+        log.info("입찰이 취소되었습니다. 입찰 ID: {}, 사용자 ID: {}, 경매 ID: {}", bid.getId(), userId, auctionId);
+    }
+}

--- a/src/main/java/org/chzz/market/domain/bid/service/BidCancelService.java
+++ b/src/main/java/org/chzz/market/domain/bid/service/BidCancelService.java
@@ -1,0 +1,30 @@
+package org.chzz.market.domain.bid.service;
+
+import static org.chzz.market.domain.bid.error.BidErrorCode.BID_NOT_ACCESSIBLE;
+import static org.chzz.market.domain.bid.error.BidErrorCode.BID_NOT_FOUND;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.chzz.market.domain.bid.entity.Bid;
+import org.chzz.market.domain.bid.error.BidException;
+import org.chzz.market.domain.bid.repository.BidRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BidCancelService {
+    private final BidRepository bidRepository;
+    private final BidCancelLockService bidCancelLockService;
+
+    /**
+     * 입찰 취소
+     */
+    public void cancel(Long bidId, Long userId) {
+        Bid bid = bidRepository.findById(bidId).orElseThrow(() -> new BidException(BID_NOT_FOUND));
+        if (!bid.isOwner(userId)) {
+            throw new BidException(BID_NOT_ACCESSIBLE);
+        }
+        bidCancelLockService.cancel(bid.getAuctionId(), bidId, userId);
+    }
+}

--- a/src/main/java/org/chzz/market/domain/bid/service/BidLookupService.java
+++ b/src/main/java/org/chzz/market/domain/bid/service/BidLookupService.java
@@ -4,9 +4,11 @@ import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.AUCTION_AC
 import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.AUCTION_NOT_FOUND;
 
 import lombok.RequiredArgsConstructor;
+import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
 import org.chzz.market.domain.auctionv2.entity.AuctionV2;
 import org.chzz.market.domain.auctionv2.error.AuctionException;
 import org.chzz.market.domain.auctionv2.repository.AuctionV2Repository;
+import org.chzz.market.domain.bid.dto.query.BiddingRecord;
 import org.chzz.market.domain.bid.dto.response.BidInfoResponse;
 import org.chzz.market.domain.bid.repository.BidQueryRepository;
 import org.springframework.data.domain.Page;
@@ -29,5 +31,9 @@ public class BidLookupService {
         }
         auction.validateAuctionEnded();
         return bidQueryRepository.findBidsByAuctionId(auctionId, pageable);
+    }
+
+    public Page<BiddingRecord> inquireBidHistory(Long userId, Pageable pageable, AuctionStatus status) {
+        return bidQueryRepository.findUsersBidHistory(userId, pageable, status);
     }
 }

--- a/src/main/java/org/chzz/market/domain/bid/service/BidLookupService.java
+++ b/src/main/java/org/chzz/market/domain/bid/service/BidLookupService.java
@@ -3,6 +3,7 @@ package org.chzz.market.domain.bid.service;
 import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.AUCTION_ACCESS_FORBIDDEN;
 import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.AUCTION_NOT_FOUND;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
 import org.chzz.market.domain.auctionv2.entity.AuctionV2;
@@ -10,6 +11,7 @@ import org.chzz.market.domain.auctionv2.error.AuctionException;
 import org.chzz.market.domain.auctionv2.repository.AuctionV2Repository;
 import org.chzz.market.domain.bid.dto.query.BiddingRecord;
 import org.chzz.market.domain.bid.dto.response.BidInfoResponse;
+import org.chzz.market.domain.bid.entity.Bid;
 import org.chzz.market.domain.bid.repository.BidQueryRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +25,9 @@ public class BidLookupService {
     private final AuctionV2Repository auctionRepository;
     private final BidQueryRepository bidQueryRepository;
 
+    /**
+     * 특정 경매의 모든 입찰 조회
+     */
     public Page<BidInfoResponse> getBidsByAuctionId(Long userId, Long auctionId, Pageable pageable) {
         AuctionV2 auction = auctionRepository.findById(auctionId)
                 .orElseThrow(() -> new AuctionException(AUCTION_NOT_FOUND));
@@ -33,7 +38,17 @@ public class BidLookupService {
         return bidQueryRepository.findBidsByAuctionId(auctionId, pageable);
     }
 
+    /**
+     * 나의 입찰 목록 조회
+     */
     public Page<BiddingRecord> inquireBidHistory(Long userId, Pageable pageable, AuctionStatus status) {
         return bidQueryRepository.findUsersBidHistory(userId, pageable, status);
+    }
+
+    /**
+     * 특정 경매의 입찰 Entity 조회 (경매 종료스케줄링에 사용)
+     */
+    public List<Bid> findAllBidsByAuction(AuctionV2 auction) {
+        return bidQueryRepository.findAllBidsByAuction(auction);
     }
 }

--- a/src/main/java/org/chzz/market/domain/bid/service/BidUpdateService.java
+++ b/src/main/java/org/chzz/market/domain/bid/service/BidUpdateService.java
@@ -1,0 +1,83 @@
+package org.chzz.market.domain.bid.service;
+
+import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.AUCTION_NOT_FOUND;
+import static org.chzz.market.domain.bid.error.BidErrorCode.BID_BELOW_MIN_PRICE;
+import static org.chzz.market.domain.bid.error.BidErrorCode.BID_BY_OWNER;
+import static org.chzz.market.domain.bid.error.BidErrorCode.BID_NOT_ACCESSIBLE;
+import static org.chzz.market.domain.bid.error.BidErrorCode.BID_NOT_FOUND;
+import static org.chzz.market.domain.user.error.UserErrorCode.USER_NOT_FOUND;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.chzz.market.domain.auctionv2.entity.AuctionV2;
+import org.chzz.market.domain.auctionv2.error.AuctionException;
+import org.chzz.market.domain.auctionv2.repository.AuctionV2Repository;
+import org.chzz.market.domain.bid.dto.BidCreateRequest;
+import org.chzz.market.domain.bid.entity.Bid;
+import org.chzz.market.domain.bid.error.BidException;
+import org.chzz.market.domain.bid.repository.BidRepository;
+import org.chzz.market.domain.user.entity.User;
+import org.chzz.market.domain.user.error.exception.UserException;
+import org.chzz.market.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class BidUpdateService {
+    private final AuctionV2Repository auctionRepository;
+    private final BidRepository bidRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void createBid(final BidCreateRequest bidCreateRequest, Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserException(USER_NOT_FOUND));
+        AuctionV2 auction = auctionRepository.findById(bidCreateRequest.getAuctionId())
+                .orElseThrow(() -> new AuctionException(AUCTION_NOT_FOUND));
+        validateBidConditions(bidCreateRequest, user.getId(), auction);
+        bidRepository.findByAuctionIdAndBidderId(auction.getId(), userId)
+                .ifPresentOrElse(
+                        // 이미 입찰을 한 경우
+                        bid -> bid.adjustBidAmount(bidCreateRequest.getBidAmount()),
+                        // 입찰을 처음 하는 경우
+                        () -> {
+                            bidRepository.save(bidCreateRequest.toEntity(user.getId()));
+                            auctionRepository.incrementBidCount(auction.getId());
+                        }
+                );
+    }
+
+    /**
+     * 입찰 취소
+     */
+    @Transactional
+    public void cancelBid(Long bidId, Long userId) {
+        Bid bid = bidRepository.findById(bidId).orElseThrow(() -> new BidException(BID_NOT_FOUND));
+        AuctionV2 auction = auctionRepository.findById(bid.getAuctionId())
+                .orElseThrow(() -> new AuctionException(AUCTION_NOT_FOUND));
+        if (!bid.isOwner(userId)) {
+            throw new BidException(BID_NOT_ACCESSIBLE);
+        }
+        auction.validateAuctionEndTime();
+        bid.cancelBid();
+        auctionRepository.decrementBidCount(auction.getId());
+        log.info("입찰이 취소되었습니다. 입찰 ID: {}, 사용자 ID: {}, 경매 ID: {}", bid.getId(), userId, auction.getId());
+    }
+
+    /**
+     * 입찰 상태 유효성 검사
+     */
+    private void validateBidConditions(BidCreateRequest bidCreateRequest, Long userId, AuctionV2 auction) {
+        // 경매 등록자가 입찰할 때
+        if (auction.isOwner(userId)) {
+            throw new BidException(BID_BY_OWNER);
+        }
+        auction.validateAuctionEndTime();
+        // 최소 금액보다 낮은 금액일 때
+        if (!auction.isAboveMinPrice(bidCreateRequest.getBidAmount())) {
+            throw new BidException(BID_BELOW_MIN_PRICE);
+        }
+    }
+}

--- a/src/main/java/org/chzz/market/domain/likev2/repository/LikeV2Repository.java
+++ b/src/main/java/org/chzz/market/domain/likev2/repository/LikeV2Repository.java
@@ -1,9 +1,12 @@
 package org.chzz.market.domain.likev2.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.chzz.market.domain.likev2.entity.LikeV2;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeV2Repository extends JpaRepository<LikeV2, Long> {
     List<LikeV2> findByAuctionId(Long auctionId);
+
+    Optional<LikeV2> findByUserIdAndAuctionId(Long userId, Long auctionId);
 }

--- a/src/main/java/org/chzz/market/domain/likev2/service/LikeUpdateService.java
+++ b/src/main/java/org/chzz/market/domain/likev2/service/LikeUpdateService.java
@@ -1,0 +1,47 @@
+package org.chzz.market.domain.likev2.service;
+
+import static org.chzz.market.domain.auctionv2.error.AuctionErrorCode.AUCTION_NOT_FOUND;
+
+import lombok.RequiredArgsConstructor;
+import org.chzz.market.domain.auctionv2.error.AuctionException;
+import org.chzz.market.domain.auctionv2.repository.AuctionV2Repository;
+import org.chzz.market.domain.likev2.entity.LikeV2;
+import org.chzz.market.domain.likev2.repository.LikeV2Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeUpdateService {
+    private final AuctionV2Repository auctionRepository;
+    private final LikeV2Repository likeRepository;
+
+    @Transactional
+    public void updateLike(Long userId, Long auctionId) {
+        auctionRepository.findById(auctionId)
+                .orElseThrow(() -> new AuctionException(AUCTION_NOT_FOUND));
+
+        likeRepository.findByUserIdAndAuctionId(userId, auctionId)
+                .ifPresentOrElse(
+                        like -> handleUnlike(like, auctionId),
+                        () -> handleLike(userId, auctionId)
+                );
+    }
+
+    private void handleUnlike(LikeV2 like, Long auctionId) {
+        likeRepository.delete(like);
+        auctionRepository.decrementLikeCount(auctionId); // TODO: 동시성문제 고려 일단 원자적 연산으로 해결
+    }
+
+    private void handleLike(Long userId, Long auctionId) {
+        likeRepository.save(createLike(userId, auctionId));
+        auctionRepository.incrementLikeCount(auctionId); // TODO: 동시성문제 고려 일단 원자적 연산으로 해결
+    }
+
+    private LikeV2 createLike(Long userId, Long auctionId) {
+        return LikeV2.builder()
+                .userId(userId)
+                .auctionId(auctionId)
+                .build();
+    }
+}

--- a/src/test/java/org/chzz/market/domain/bid/service/BidCancelLockServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/bid/service/BidCancelLockServiceTest.java
@@ -1,0 +1,162 @@
+package org.chzz.market.domain.bid.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
+import org.chzz.market.domain.auctionv2.entity.AuctionV2;
+import org.chzz.market.domain.auctionv2.entity.Category;
+import org.chzz.market.domain.auctionv2.repository.AuctionV2Repository;
+import org.chzz.market.domain.bid.entity.Bid;
+import org.chzz.market.domain.bid.error.BidErrorCode;
+import org.chzz.market.domain.bid.error.BidException;
+import org.chzz.market.domain.bid.repository.BidRepository;
+import org.chzz.market.domain.image.entity.ImageV2;
+import org.chzz.market.domain.user.entity.User;
+import org.chzz.market.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BidCancelLockServiceTest {
+
+    @Autowired
+    private BidCancelLockService bidCancelLockService;
+
+    @Autowired
+    private AuctionV2Repository auctionRepository;
+
+    @Autowired
+    private BidRepository bidRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private AuctionV2 auction;
+    private User seller;
+    private List<User> users;
+    private List<Bid> bids;
+    private ImageV2 defaultImage;
+
+    @BeforeEach
+    public void setUp() {
+        seller = User.builder().email("seller").providerId("seller").providerType(User.ProviderType.KAKAO).build();
+        userRepository.save(seller);
+        defaultImage = ImageV2.builder().cdnPath("https://cdn.com").sequence(1).build();
+        users = IntStream.range(1, 6)
+                .mapToObj(i -> User.builder()
+                        .email("user" + i + "@example.com")
+                        .providerId("user" + i)
+                        .providerType(User.ProviderType.KAKAO)
+                        .build())
+                .map(userRepository::save)
+                .collect(Collectors.toList());
+        auction = auctionRepository.save(
+                createAuction(seller, "맥북프로", "맥북프로 2019년형 팝니다.", AuctionStatus.PROCEEDING, null));
+        users.forEach(user -> bidRepository.save(
+                Bid.builder().auctionId(auction.getId()).bidderId(user.getId()).amount(1000L).build()));
+        bids = users.stream()
+                .map(user -> Bid.builder()
+                        .auctionId(auction.getId())
+                        .bidderId(user.getId())
+                        .amount(1000L)
+                        .build())
+                .map(bidRepository::save)
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void multipleUsersCancelBidTest() throws InterruptedException {
+        int numberOfThreads = users.size();
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            final long userId = users.get(i).getId();
+            final long bidId = bids.get(i).getId();
+            executorService.execute(() -> {
+                try {
+                    bidCancelLockService.cancel(auction.getId(), bidId, userId);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // Auction 업데이트 후 결과 검증
+        AuctionV2 updatedAuction = auctionRepository.findById(auction.getId()).orElseThrow();
+        long bidCount = updatedAuction.getBidCount();
+
+        // 모든 입찰 취소 후 카운트 0 검증
+        assertThat(bidCount).isEqualTo(0);
+    }
+
+    @Test
+    public void singleUserConcurrentCancelBidTest_ThrowsException() throws InterruptedException {
+        int numberOfThreads = 3; // 동일한 사용자가 동시에 요청
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        // 예외를 수집할 리스트
+        List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            final long userId = users.get(0).getId();
+            final long bidId = bids.get(0).getId();
+            executorService.execute(() -> {
+                try {
+                    bidCancelLockService.cancel(auction.getId(), bidId, userId);
+                } catch (Exception e) {
+                    exceptions.add(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // 하나의 성공한 요청과 두 개의 예외 발생 확인
+        assertThat(exceptions).hasSize(numberOfThreads - 1); // 예외는 2개 발생해야 함
+        assertThat(exceptions.get(0))
+                .isInstanceOf(BidException.class)
+                .extracting("errorCode")
+                .isEqualTo(BidErrorCode.BID_ALREADY_CANCELLED);
+
+        // 최종 입찰 수 확인 (4가 되어야 함)
+        AuctionV2 updatedAuction = auctionRepository.findById(auction.getId()).orElseThrow();
+        long bidCount = updatedAuction.getBidCount();
+        assertThat(bidCount).isEqualTo(4);
+    }
+
+    private AuctionV2 createAuction(User seller, String name, String description, AuctionStatus status, Long winnerId) {
+        AuctionV2 auction = AuctionV2.builder()
+                .seller(seller)
+                .name(name)
+                .description(description)
+                .status(status)
+                .category(Category.ELECTRONICS)
+                .winnerId(winnerId)
+                .minPrice(1000)
+                .bidCount(5L)
+                .endDateTime(LocalDateTime.now().plusDays(2))
+                .build();
+        auction.addImage(defaultImage);
+        auctionRepository.save(auction);
+        return auction;
+    }
+}

--- a/src/test/java/org/chzz/market/domain/bid/service/BidCreateServiceConcurrencyTest.java
+++ b/src/test/java/org/chzz/market/domain/bid/service/BidCreateServiceConcurrencyTest.java
@@ -1,0 +1,142 @@
+package org.chzz.market.domain.bid.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
+import org.chzz.market.domain.auctionv2.entity.AuctionV2;
+import org.chzz.market.domain.auctionv2.entity.Category;
+import org.chzz.market.domain.auctionv2.repository.AuctionV2Repository;
+import org.chzz.market.domain.bid.dto.BidCreateRequest;
+import org.chzz.market.domain.bid.error.BidErrorCode;
+import org.chzz.market.domain.bid.error.BidException;
+import org.chzz.market.domain.image.entity.ImageV2;
+import org.chzz.market.domain.user.entity.User;
+import org.chzz.market.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class BidCreateServiceConcurrencyTest {
+
+    @Autowired
+    private BidCreateService bidCreateService;
+
+    @Autowired
+    private AuctionV2Repository auctionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private AuctionV2 auction;
+    private User seller;
+    private List<User> users;
+    private ImageV2 defaultImage;
+
+    @BeforeEach
+    public void setUp() {
+        seller = User.builder().email("seller").providerId("seller").providerType(User.ProviderType.KAKAO).build();
+        userRepository.save(seller);
+        defaultImage = ImageV2.builder().cdnPath("https://cdn.com").sequence(1).build();
+        auction = auctionRepository.save(
+                createAuction(seller, "맥북프로", "맥북프로 2019년형 팝니다.", AuctionStatus.PROCEEDING, null));
+        users = IntStream.range(1, 6)
+                .mapToObj(i -> User.builder()
+                        .email("user" + i + "@example.com")
+                        .providerId("user" + i)
+                        .providerType(User.ProviderType.KAKAO)
+                        .build())
+                .map(userRepository::save)
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void createBidConcurrencyTest() throws InterruptedException {
+        int numberOfThreads = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            final long userId = users.get(i).getId();
+            executorService.execute(() -> {
+                try {
+                    BidCreateRequest bidRequest = new BidCreateRequest(auction.getId(), 1000L);
+                    bidCreateService.create(bidRequest, userId);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        AuctionV2 updatedAuction = auctionRepository.findById(auction.getId()).orElseThrow();
+        long bidCount = updatedAuction.getBidCount();
+        assertThat(bidCount).isEqualTo(numberOfThreads);
+    }
+
+    @Test
+    public void singleUserConcurrentBidTest_ThrowsException() throws InterruptedException {
+        int numberOfThreads = 3; // 동일한 사용자가 동시에 요청
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        // 예외를 수집할 리스트
+        List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.execute(() -> {
+                try {
+                    BidCreateRequest bidRequest = new BidCreateRequest(auction.getId(), 1000L);
+                    bidCreateService.create(bidRequest, users.get(0).getId());
+                } catch (Exception e) {
+                    exceptions.add(e); // 예외를 리스트에 추가
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // 하나의 성공한 입찰과 두 개의 예외 발생 확인
+        assertThat(exceptions).hasSize(numberOfThreads - 1); // 예외는 두 개 발생해야 함
+        assertThat(exceptions.get(0))
+                .isInstanceOf(BidException.class)
+                .extracting("errorCode")
+                .isEqualTo(BidErrorCode.BID_SAME_AS_PREVIOUS);
+
+        // 최종 입찰 수 확인 (1번만 성공)
+        AuctionV2 updatedAuction = auctionRepository.findById(auction.getId()).orElseThrow();
+        long bidCount = updatedAuction.getBidCount();
+        assertThat(bidCount).isEqualTo(1);
+    }
+
+    private AuctionV2 createAuction(User seller, String name, String description, AuctionStatus status, Long winnerId) {
+        AuctionV2 auction = AuctionV2.builder()
+                .seller(seller)
+                .name(name)
+                .description(description)
+                .status(status)
+                .category(Category.ELECTRONICS)
+                .winnerId(winnerId)
+                .minPrice(1000)
+                .endDateTime(LocalDateTime.now().plusDays(2))
+                .build();
+        auction.addImage(defaultImage);
+        auctionRepository.save(auction);
+        return auction;
+    }
+}

--- a/src/test/java/org/chzz/market/domain/bid/service/BidCreateServiceConcurrencyTest.java
+++ b/src/test/java/org/chzz/market/domain/bid/service/BidCreateServiceConcurrencyTest.java
@@ -61,7 +61,7 @@ public class BidCreateServiceConcurrencyTest {
     }
 
     @Test
-    public void createBidConcurrencyTest() throws InterruptedException {
+    public void 하나의_경매에_여러명이_입찰할때_동시성테스트() throws InterruptedException {
         int numberOfThreads = 5;
         ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
         CountDownLatch latch = new CountDownLatch(numberOfThreads);
@@ -87,7 +87,7 @@ public class BidCreateServiceConcurrencyTest {
     }
 
     @Test
-    public void singleUserConcurrentBidTest_ThrowsException() throws InterruptedException {
+    public void 하나의경매에_동일한_사용자가_입찰요청을_할경우_예외가_발생한다() throws InterruptedException {
         int numberOfThreads = 3; // 동일한 사용자가 동시에 요청
         ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
         CountDownLatch latch = new CountDownLatch(numberOfThreads);

--- a/src/test/java/org/chzz/market/domain/likev2/service/LikeUpdateServiceConcurrencyTest.java
+++ b/src/test/java/org/chzz/market/domain/likev2/service/LikeUpdateServiceConcurrencyTest.java
@@ -1,0 +1,85 @@
+package org.chzz.market.domain.likev2.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.chzz.market.domain.auctionv2.entity.AuctionStatus;
+import org.chzz.market.domain.auctionv2.entity.AuctionV2;
+import org.chzz.market.domain.auctionv2.entity.Category;
+import org.chzz.market.domain.auctionv2.repository.AuctionV2Repository;
+import org.chzz.market.domain.image.entity.ImageV2;
+import org.chzz.market.domain.user.entity.User;
+import org.chzz.market.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class LikeUpdateServiceConcurrencyTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LikeUpdateService likeUpdateService;
+
+    @Autowired
+    private AuctionV2Repository auctionRepository;
+
+    private User seller;
+    private User user;
+    private ImageV2 defaultImage;
+
+    @BeforeEach
+    void setUp() {
+        seller = User.builder().email("seller").providerId("seller").providerType(User.ProviderType.KAKAO).build();
+        user = User.builder().email("user").providerId("user").providerType(User.ProviderType.KAKAO).build();
+        defaultImage = ImageV2.builder().cdnPath("https://cdn.com").sequence(1).build();
+        userRepository.save(seller);
+        userRepository.save(user);
+    }
+
+    @Test
+    public void testUpdateLikeConcurrency() throws InterruptedException {
+        AuctionV2 auction = createAuction(seller, "맥북프로", "맥북프로 2019년형 팝니다.", AuctionStatus.PROCEEDING, null);
+
+        int numberOfThreads = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        // WHEN
+        for (int i = 0; i < numberOfThreads; i++) {
+            long userId = i + 1;
+            executorService.execute(() -> {
+                try {
+                    likeUpdateService.updateLike(userId, auction.getId());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        AuctionV2 updatedAuction = auctionRepository.findById(auction.getId())
+                .orElseThrow(() -> new RuntimeException("Auction not found"));
+        assertThat(updatedAuction.getLikeCount()).isEqualTo(100);
+    }
+
+    private AuctionV2 createAuction(User seller, String name, String description, AuctionStatus status, Long winnerId) {
+        AuctionV2 auction = AuctionV2.builder()
+                .seller(seller)
+                .name(name)
+                .description(description)
+                .status(status)
+                .category(Category.ELECTRONICS)
+                .winnerId(winnerId)
+                .build();
+        auction.addImage(defaultImage);
+        auctionRepository.save(auction);
+        return auction;
+    }
+}

--- a/src/test/java/org/chzz/market/domain/likev2/service/LikeUpdateServiceConcurrencyTest.java
+++ b/src/test/java/org/chzz/market/domain/likev2/service/LikeUpdateServiceConcurrencyTest.java
@@ -42,7 +42,7 @@ public class LikeUpdateServiceConcurrencyTest {
     }
 
     @Test
-    public void testUpdateLikeConcurrency() throws InterruptedException {
+    public void 좋아요_동시성_테스트() throws InterruptedException {
         AuctionV2 auction = createAuction(seller, "맥북프로", "맥북프로 2019년형 팝니다.", AuctionStatus.PROCEEDING, null);
 
         int numberOfThreads = 100;


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-이슈번호]

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- [x]  (사전) 경매 좋아요(찜) 요청 및 취소 전환
- [x]  입찰 요청 및  수정 (입찰수증가) 전환
- [x]  입찰 취소할때 (입찰수 감소) 전환
- [x]  나의 입찰 내역 조회 전환

## ✅테스트 결과

![스크린샷 2024-11-20 오전 3 10 53](https://github.com/user-attachments/assets/f9337c3b-d043-4619-b239-e40d8ba0d63e)

## 🙏리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->

- 일단 동시성 문제 원자적 연산으로 해결했습니다.
