### PR TITLE
feat: 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/org/chzz/market/common/config/OAuth2ClientConfig.java
+++ b/src/main/java/org/chzz/market/common/config/OAuth2ClientConfig.java
@@ -1,0 +1,16 @@
+package org.chzz.market.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+
+@Configuration
+public class OAuth2ClientConfig {
+
+    @Bean
+    public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient() {
+        return new DefaultAuthorizationCodeTokenResponseClient();
+    }
+}

--- a/src/main/java/org/chzz/market/common/config/RestClientConfig.java
+++ b/src/main/java/org/chzz/market/common/config/RestClientConfig.java
@@ -1,0 +1,13 @@
+package org.chzz.market.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+    @Bean
+    RestClient restClient() {
+        return RestClient.create();
+    }
+}

--- a/src/main/java/org/chzz/market/common/config/SecurityConfig.java
+++ b/src/main/java/org/chzz/market/common/config/SecurityConfig.java
@@ -14,9 +14,10 @@ import org.chzz.market.common.filter.HttpCookieOAuth2AuthorizationRequestReposit
 import org.chzz.market.common.filter.JWTFilter;
 import org.chzz.market.common.filter.NotFoundFilter;
 import org.chzz.market.common.util.JWTUtil;
-import org.chzz.market.domain.user.oauth2.CustomFailureHandler;
-import org.chzz.market.domain.user.oauth2.CustomSuccessHandler;
-import org.chzz.market.domain.user.service.CustomOAuth2UserService;
+import org.chzz.market.domain.oauth2.service.CustomFailureHandler;
+import org.chzz.market.domain.oauth2.service.CustomOAuth2LoginAuthenticationProvider;
+import org.chzz.market.domain.oauth2.service.CustomOAuth2UserService;
+import org.chzz.market.domain.oauth2.service.CustomSuccessHandler;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,6 +43,7 @@ public class SecurityConfig {
     @Value("${client.url}")
     private String clientUrl;
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomOAuth2LoginAuthenticationProvider customOAuth2LoginAuthenticationProvider;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomSuccessHandler customSuccessHandler;
@@ -53,28 +55,19 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
-        return http.authorizeHttpRequests(authorize -> authorize
+        return http
+                .authenticationProvider(customOAuth2LoginAuthenticationProvider)
+                .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(ACTUATOR).permitAll()
                         .requestMatchers("/metrics").permitAll()
                         .requestMatchers("/api-docs", "/swagger-ui/**", "/api/v3/api-docs/**").permitAll()
                         .requestMatchers(GET,
                                 "/api/v1/auctions",
                                 "/api/v1/auctions/{auctionId:\\d+}",
-                                "/api/v1/auctions/{auctionId:\\d+}/simple",
-                                "/api/v1/auctions/best",
-                                "/api/v1/auctions/imminent",
-                                "/api/v1/auctions/users/*",
-                                "/api/v1/products",
-                                "/api/v1/products/categories",
-                                "/api/v1/products/{productId:\\d+}",
-                                "/api/v1/products/users/*",
+                                "/api/v1/auctions/categories",
                                 "/api/v1/notifications/subscribe",
                                 "/api/v1/users/*",
                                 "/api/v1/users/check/nickname/*").permitAll()
-                        .requestMatchers(GET,
-                                "/api/v2/auctions",
-                                "/api/v2/auctions/categories",
-                                "/api/v2/auctions/{auctionId:\\d+}").permitAll()
                         .requestMatchers(POST,
                                 "/api/v1/users/tokens/reissue").permitAll()
                         .requestMatchers(POST, "/api/v1/users").hasRole("TEMP_USER")

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionQueryRepository.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionQueryRepository.java
@@ -489,6 +489,18 @@ public class AuctionQueryRepository {
         );
     }
 
+    /**
+     * 현재 사용자가 입찰 진행 중인 경매 갯수 조회
+     */
+    public long countProceedingAuctionsByUserId(Long userId) {
+        return jpaQueryFactory
+                .select(auction.count())
+                .from(auction)
+                .join(bid).on(bid.auctionId.eq(auction.id)).on(bid.bidderId.eq(userId).and(bid.status.eq(ACTIVE)))
+                .where(auction.status.eq(PROCEEDING))
+                .fetchOne();
+    }
+
     private List<ImageResponse> getImagesByAuctionId(Long auctionId) {
         return jpaQueryFactory
                 .select(new QImageResponse(image.id, image.cdnPath))

--- a/src/main/java/org/chzz/market/domain/oauth2/dto/response/KaKaoResponse.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/dto/response/KaKaoResponse.java
@@ -1,4 +1,4 @@
-package org.chzz.market.domain.user.dto.response;
+package org.chzz.market.domain.oauth2.dto.response;
 
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/org/chzz/market/domain/oauth2/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,4 @@
+package org.chzz.market.domain.oauth2.dto.response;
+
+public record KakaoTokenResponse(String token_type, String access_token, Integer expires_in) {
+}

--- a/src/main/java/org/chzz/market/domain/oauth2/dto/response/KakaoUnlinkResponse.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/dto/response/KakaoUnlinkResponse.java
@@ -1,0 +1,4 @@
+package org.chzz.market.domain.oauth2.dto.response;
+
+public record KakaoUnlinkResponse(Long id) {
+}

--- a/src/main/java/org/chzz/market/domain/oauth2/dto/response/NaverResponse.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/dto/response/NaverResponse.java
@@ -1,4 +1,4 @@
-package org.chzz.market.domain.user.dto.response;
+package org.chzz.market.domain.oauth2.dto.response;
 
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/org/chzz/market/domain/oauth2/dto/response/NaverTokenResponse.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/dto/response/NaverTokenResponse.java
@@ -1,0 +1,4 @@
+package org.chzz.market.domain.oauth2.dto.response;
+
+public record NaverTokenResponse(String access_token, String token_type, String expires_in) {
+}

--- a/src/main/java/org/chzz/market/domain/oauth2/dto/response/NaverUnlinkResponse.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/dto/response/NaverUnlinkResponse.java
@@ -1,0 +1,4 @@
+package org.chzz.market.domain.oauth2.dto.response;
+
+public record NaverUnlinkResponse(String access_token, String result) {
+}

--- a/src/main/java/org/chzz/market/domain/oauth2/dto/response/OAuth2Response.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/dto/response/OAuth2Response.java
@@ -1,4 +1,4 @@
-package org.chzz.market.domain.user.dto.response;
+package org.chzz.market.domain.oauth2.dto.response;
 
 import static org.chzz.market.domain.user.entity.User.UserRole.TEMP_USER;
 

--- a/src/main/java/org/chzz/market/domain/oauth2/repository/Oauth2RefreshTokenRepository.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/repository/Oauth2RefreshTokenRepository.java
@@ -1,0 +1,34 @@
+package org.chzz.market.domain.oauth2.repository;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.chzz.market.domain.token.entity.TokenType;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class Oauth2RefreshTokenRepository {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void save(String providerType, String providerId, String refreshToken) {
+        String key = generateKey(providerType, providerId);
+        redisTemplate.opsForValue().set(key, refreshToken);
+        redisTemplate.expire(key, TokenType.REFRESH.getExpirationTime(), TimeUnit.SECONDS);
+    }
+
+    public Optional<String> find(String providerType, String providerId) {
+        String key = generateKey(providerType, providerId);
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key));
+    }
+
+    public void delete(String providerType, String providerId) {
+        String key = generateKey(providerType, providerId);
+        redisTemplate.delete(key);
+    }
+
+    private String generateKey(String providerType, String providerId) {
+        return providerType + ":" + providerId;
+    }
+}

--- a/src/main/java/org/chzz/market/domain/oauth2/service/CustomFailureHandler.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/service/CustomFailureHandler.java
@@ -1,4 +1,4 @@
-package org.chzz.market.domain.user.oauth2;
+package org.chzz.market.domain.oauth2.service;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/org/chzz/market/domain/oauth2/service/CustomOAuth2LoginAuthenticationProvider.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/service/CustomOAuth2LoginAuthenticationProvider.java
@@ -1,0 +1,41 @@
+package org.chzz.market.domain.oauth2.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.chzz.market.domain.user.dto.CustomUserDetails;
+import org.chzz.market.domain.oauth2.repository.Oauth2RefreshTokenRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.client.authentication.OAuth2LoginAuthenticationProvider;
+import org.springframework.security.oauth2.client.authentication.OAuth2LoginAuthenticationToken;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class CustomOAuth2LoginAuthenticationProvider extends OAuth2LoginAuthenticationProvider {
+    private final Oauth2RefreshTokenRepository oauth2RefreshTokenRepository;
+
+    public CustomOAuth2LoginAuthenticationProvider(
+            OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient,
+            OAuth2UserService<OAuth2UserRequest, OAuth2User> userService,
+            Oauth2RefreshTokenRepository oauth2RefreshTokenRepository) {
+        super(accessTokenResponseClient, userService);
+        this.oauth2RefreshTokenRepository = oauth2RefreshTokenRepository;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        OAuth2LoginAuthenticationToken authenticationResult = (OAuth2LoginAuthenticationToken) super.authenticate(
+                authentication);
+        CustomUserDetails userDetails = (CustomUserDetails) authenticationResult.getPrincipal();
+        String refreshToken = authenticationResult.getRefreshToken().getTokenValue();
+        String providerType = authenticationResult.getClientRegistration().getRegistrationId();
+        String providerId = userDetails.getProviderId();
+        oauth2RefreshTokenRepository.save(providerType, providerId, refreshToken);
+        return authenticationResult;
+    }
+}

--- a/src/main/java/org/chzz/market/domain/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/service/CustomOAuth2UserService.java
@@ -2,10 +2,10 @@ package org.chzz.market.domain.oauth2.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.chzz.market.domain.user.dto.CustomUserDetails;
 import org.chzz.market.domain.oauth2.dto.response.KaKaoResponse;
 import org.chzz.market.domain.oauth2.dto.response.NaverResponse;
 import org.chzz.market.domain.oauth2.dto.response.OAuth2Response;
+import org.chzz.market.domain.user.dto.CustomUserDetails;
 import org.chzz.market.domain.user.entity.User;
 import org.chzz.market.domain.user.entity.User.ProviderType;
 import org.chzz.market.domain.user.repository.UserRepository;
@@ -34,17 +34,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         if (registrationId == null) {
             throw new OAuth2AuthenticationException("유효하지않는 OAuth2 제공자입니다.");
         }
-        OAuth2Response oAuth2Response;
-        switch (providerType) {
-            case NAVER:
-                oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
-                break;
-            case KAKAO:
-                oAuth2Response = new KaKaoResponse(oAuth2User.getAttributes());
-                break;
-            default:
-                throw new OAuth2AuthenticationException("지원되지 않는 OAuth2 제공자입니다.");
-        }
+        OAuth2Response oAuth2Response = switch (providerType) {
+            case NAVER -> new NaverResponse(oAuth2User.getAttributes());
+            case KAKAO -> new KaKaoResponse(oAuth2User.getAttributes());
+        };
         User user = findOrCreateMember(oAuth2Response, providerType);
         return new CustomUserDetails(user, oAuth2User.getAttributes());
     }

--- a/src/main/java/org/chzz/market/domain/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/service/CustomOAuth2UserService.java
@@ -1,11 +1,11 @@
-package org.chzz.market.domain.user.service;
+package org.chzz.market.domain.oauth2.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.chzz.market.domain.user.dto.CustomUserDetails;
-import org.chzz.market.domain.user.dto.response.KaKaoResponse;
-import org.chzz.market.domain.user.dto.response.NaverResponse;
-import org.chzz.market.domain.user.dto.response.OAuth2Response;
+import org.chzz.market.domain.oauth2.dto.response.KaKaoResponse;
+import org.chzz.market.domain.oauth2.dto.response.NaverResponse;
+import org.chzz.market.domain.oauth2.dto.response.OAuth2Response;
 import org.chzz.market.domain.user.entity.User;
 import org.chzz.market.domain.user.entity.User.ProviderType;
 import org.chzz.market.domain.user.repository.UserRepository;

--- a/src/main/java/org/chzz/market/domain/oauth2/service/CustomSuccessHandler.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/service/CustomSuccessHandler.java
@@ -1,4 +1,4 @@
-package org.chzz.market.domain.user.oauth2;
+package org.chzz.market.domain.oauth2.service;
 
 import static org.chzz.market.common.util.CookieUtil.createTokenCookie;
 

--- a/src/main/java/org/chzz/market/domain/oauth2/service/KakaoSocialLoginService.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/service/KakaoSocialLoginService.java
@@ -1,0 +1,84 @@
+package org.chzz.market.domain.oauth2.service;
+
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.chzz.market.domain.oauth2.dto.response.KakaoTokenResponse;
+import org.chzz.market.domain.oauth2.dto.response.KakaoUnlinkResponse;
+import org.chzz.market.domain.oauth2.repository.Oauth2RefreshTokenRepository;
+import org.chzz.market.domain.user.entity.User.ProviderType;
+import org.chzz.market.domain.user.error.UserErrorCode;
+import org.chzz.market.domain.user.error.exception.UserException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoSocialLoginService implements SocialLoginService {
+    private static final String KAKAO_UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
+    private static final String CONTENT_TYPE = APPLICATION_FORM_URLENCODED_VALUE + ";charset=utf-8";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_TOKEN_PREFIX = "Bearer ";
+
+    private final RestClient restClient;
+    private final Oauth2RefreshTokenRepository oauth2RefreshTokenRepository;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private String kakaoTokenUrl;
+
+    @Value("${oauth2.kakao.rest-api-key}")
+    private String restApiKey;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+
+    @Override
+    public void disconnect(ProviderType providerType, String providerId) {
+        String accessToken = getAccessToken(providerType, providerId);
+        KakaoUnlinkResponse kakaoUnlinkResponse = restClient.post()
+                .uri(KAKAO_UNLINK_URL)
+                .header(AUTHORIZATION_HEADER, BEARER_TOKEN_PREFIX + accessToken)
+                .contentType(MediaType.valueOf(CONTENT_TYPE))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (request, response) -> {
+                    log.error("카카오 연결끊기에 실패하였습니다. response status={}", response.getStatusCode());
+                    throw new UserException(UserErrorCode.KAKAO_UNLINK_FAILED);
+                })
+                .body(KakaoUnlinkResponse.class);
+        log.info("카카오 providerId {} 의 연결이 성공적으로 끊어졌습니다.", kakaoUnlinkResponse.id());
+        oauth2RefreshTokenRepository.delete(providerType.getName(), providerId);
+    }
+
+    @Override
+    public String getAccessToken(ProviderType providerType, String providerId) {
+        String refreshToken = oauth2RefreshTokenRepository.find(providerType.getName(), providerId)
+                .orElseThrow(() -> new UserException(UserErrorCode.KAKAO_UNLINK_FAILED));
+        KakaoTokenResponse kakaoTokenResponse = restClient.post()
+                .uri(kakaoTokenUrl)
+                .contentType(MediaType.valueOf(CONTENT_TYPE))
+                .body(createRefreshTokenRequestBody(refreshToken))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (request, response) -> {
+                    log.error("Access 토큰 발급에 실패하였습니다. 응답 상태: {}", response.getStatusCode());
+                    throw new UserException(UserErrorCode.KAKAO_UNLINK_FAILED);
+                })
+                .body(KakaoTokenResponse.class);
+        return kakaoTokenResponse.access_token();
+    }
+
+    private MultiValueMap<String, String> createRefreshTokenRequestBody(String refreshToken) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "refresh_token");
+        body.add("client_id", restApiKey);
+        body.add("refresh_token", refreshToken);
+        body.add("client_secret", clientSecret);
+        return body;
+    }
+}

--- a/src/main/java/org/chzz/market/domain/oauth2/service/NaverSocialLoginService.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/service/NaverSocialLoginService.java
@@ -1,0 +1,103 @@
+package org.chzz.market.domain.oauth2.service;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.chzz.market.domain.oauth2.dto.response.NaverTokenResponse;
+import org.chzz.market.domain.oauth2.dto.response.NaverUnlinkResponse;
+import org.chzz.market.domain.oauth2.repository.Oauth2RefreshTokenRepository;
+import org.chzz.market.domain.user.entity.User.ProviderType;
+import org.chzz.market.domain.user.error.UserErrorCode;
+import org.chzz.market.domain.user.error.exception.UserException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NaverSocialLoginService implements SocialLoginService {
+    private static final String GRANT_TYPE_DELETE = "delete";
+    private static final String GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
+    private static final String CLIENT_ID_PARAM = "client_id";
+    private static final String CLIENT_SECRET_PARAM = "client_secret";
+    private static final String ACCESS_TOKEN_PARAM = "access_token";
+    private static final String REFRESH_TOKEN_PARAM = "refresh_token";
+    private static final String GRANT_TYPE_PARAM = "grant_type";
+
+    private final RestClient restClient;
+    private final Oauth2RefreshTokenRepository oauth2RefreshTokenRepository;
+
+    @Value("${spring.security.oauth2.client.provider.naver.token-uri}")
+    private String naverTokenUrl;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String clientSecret;
+
+    @Override
+    public void disconnect(ProviderType providerType, String providerId) {
+        String accessToken = getAccessToken(providerType, providerId);
+
+        URI uri = UriComponentsBuilder.fromUriString(naverTokenUrl)
+                .queryParams(createDisconnectParams(accessToken))
+                .build()
+                .toUri();
+
+        NaverUnlinkResponse naverUnlinkResponse = restClient.get()
+                .uri(uri)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (request, response) -> {
+                    log.error("네이버 연결 끊기에 실패하였습니다. 응답 상태: {}", response.getStatusCode());
+                    throw new UserException(UserErrorCode.NAVER_UNLINK_FAILED);
+                })
+                .body(NaverUnlinkResponse.class);
+        log.info("네이버 providerId {} 의 연결이 성공적으로 끊어졌습니다. 결과: {}", providerId, naverUnlinkResponse.result());
+        oauth2RefreshTokenRepository.delete(providerType.getName(), providerId);
+    }
+
+    private MultiValueMap<String, String> createDisconnectParams(String accessToken) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add(CLIENT_ID_PARAM, clientId);
+        params.add(CLIENT_SECRET_PARAM, clientSecret);
+        params.add(ACCESS_TOKEN_PARAM, accessToken);
+        params.add(GRANT_TYPE_PARAM, GRANT_TYPE_DELETE);
+        return params;
+    }
+
+    @Override
+    public String getAccessToken(ProviderType providerType, String providerId) {
+        String refreshToken = oauth2RefreshTokenRepository.find(providerType.getName(), providerId)
+                .orElseThrow(() -> new UserException(UserErrorCode.NAVER_UNLINK_FAILED));
+
+        URI uri = UriComponentsBuilder.fromUriString(naverTokenUrl)
+                .queryParams(createRefreshTokenParams(refreshToken))
+                .build()
+                .toUri();
+
+        NaverTokenResponse naverTokenResponse = restClient.get()
+                .uri(uri)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (request, response) -> {
+                    log.error("네이버 액세스 토큰 발급에 실패하였습니다. 응답 상태: {}", response.getStatusCode());
+                    throw new UserException(UserErrorCode.NAVER_UNLINK_FAILED);
+                })
+                .body(NaverTokenResponse.class);
+        return naverTokenResponse.access_token();
+    }
+
+    private MultiValueMap<String, String> createRefreshTokenParams(String refreshToken) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add(CLIENT_ID_PARAM, clientId);
+        params.add(CLIENT_SECRET_PARAM, clientSecret);
+        params.add(REFRESH_TOKEN_PARAM, refreshToken);
+        params.add(GRANT_TYPE_PARAM, GRANT_TYPE_REFRESH_TOKEN);
+        return params;
+    }
+}

--- a/src/main/java/org/chzz/market/domain/oauth2/service/SocialLoginEventListener.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/service/SocialLoginEventListener.java
@@ -1,0 +1,22 @@
+package org.chzz.market.domain.oauth2.service;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+import lombok.RequiredArgsConstructor;
+import org.chzz.market.domain.user.dto.UserDeletedEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class SocialLoginEventListener {
+    private final SocialLoginServiceFactory socialLoginServiceFactory;
+
+    @Async("threadPoolTaskExecutor")
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handleUserDeletedEvent(UserDeletedEvent event) {
+        SocialLoginService socialLoginService = socialLoginServiceFactory.getService(event.type());
+        socialLoginService.disconnect(event.type(), event.providerId());
+    }
+}

--- a/src/main/java/org/chzz/market/domain/oauth2/service/SocialLoginService.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/service/SocialLoginService.java
@@ -1,0 +1,9 @@
+package org.chzz.market.domain.oauth2.service;
+
+import org.chzz.market.domain.user.entity.User.ProviderType;
+
+public interface SocialLoginService {
+    String getAccessToken(ProviderType providerType, String providerId);
+
+    void disconnect(ProviderType providerType, String providerId);
+}

--- a/src/main/java/org/chzz/market/domain/oauth2/service/SocialLoginServiceFactory.java
+++ b/src/main/java/org/chzz/market/domain/oauth2/service/SocialLoginServiceFactory.java
@@ -1,0 +1,19 @@
+package org.chzz.market.domain.oauth2.service;
+
+import lombok.RequiredArgsConstructor;
+import org.chzz.market.domain.user.entity.User.ProviderType;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SocialLoginServiceFactory {
+    private final KakaoSocialLoginService kakaoSocialLoginService;
+    private final NaverSocialLoginService naverSocialLoginService;
+
+    public SocialLoginService getService(ProviderType providerType) {
+        return switch (providerType) {
+            case KAKAO -> kakaoSocialLoginService;
+            case NAVER -> naverSocialLoginService;
+        };
+    }
+}

--- a/src/main/java/org/chzz/market/domain/token/service/TokenService.java
+++ b/src/main/java/org/chzz/market/domain/token/service/TokenService.java
@@ -50,9 +50,10 @@ public class TokenService {
 
     public void logout(String refreshToken) {
         jwtUtil.validateToken(refreshToken, TokenType.REFRESH);
-        Long userId = refreshTokenRepository.findByToken(refreshToken)
-                .orElseThrow(() -> new TokenException(TokenErrorCode.REFRESH_TOKEN_NOT_FOUND)).userId();
-        refreshTokenRepository.deleteByToken(refreshToken);
-        log.info("사용자 ID {}: 로그아웃이 완료되었습니다.", userId);
+
+        refreshTokenRepository.findByToken(refreshToken).ifPresent(tokenData -> {
+            refreshTokenRepository.deleteByToken(refreshToken);
+            log.info("사용자 ID {}: 로그아웃이 완료되었습니다.", tokenData.userId());
+        });
     }
 }

--- a/src/main/java/org/chzz/market/domain/user/controller/UserApi.java
+++ b/src/main/java/org/chzz/market/domain/user/controller/UserApi.java
@@ -1,15 +1,22 @@
 package org.chzz.market.domain.user.controller;
 
+import static org.chzz.market.domain.user.error.UserErrorCode.Const.CANNOT_DELETE_USER_DUE_TO_ONGOING_AUCTIONS;
+import static org.chzz.market.domain.user.error.UserErrorCode.Const.CANNOT_DELETE_USER_DUE_TO_ONGOING_BIDS;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.Map;
+import org.chzz.market.common.config.LoginUser;
+import org.chzz.market.common.springdoc.ApiExceptionExplanation;
+import org.chzz.market.common.springdoc.ApiResponseExplanations;
 import org.chzz.market.domain.user.dto.request.UpdateUserProfileRequest;
 import org.chzz.market.domain.user.dto.request.UserCreateRequest;
 import org.chzz.market.domain.user.dto.response.NicknameAvailabilityResponse;
 import org.chzz.market.domain.user.dto.response.UserProfileResponse;
+import org.chzz.market.domain.user.error.UserErrorCode;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
@@ -38,4 +45,14 @@ public interface UserApi {
 
     @Operation(summary = "로그아웃")
     ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response);
+
+    @Operation(summary = "회원탈퇴", description = "회원 탈퇴 시 진행 중인 경매나 입찰이 있을 경우 탈퇴가 불가능합니다.")
+    @ApiResponseExplanations(
+            errors = {
+                    @ApiExceptionExplanation(value = UserErrorCode.class, constant = CANNOT_DELETE_USER_DUE_TO_ONGOING_AUCTIONS, name = "진행 중인 경매가 있어 회원 탈퇴가 불가능한 경우"),
+                    @ApiExceptionExplanation(value = UserErrorCode.class, constant = CANNOT_DELETE_USER_DUE_TO_ONGOING_BIDS, name = "진행 중인 입찰이 있어 회원 탈퇴가 불가능한 경우"),
+            }
+    )
+    ResponseEntity<Void> deleteUser(@LoginUser Long userId, HttpServletRequest request, HttpServletResponse response);
+
 }

--- a/src/main/java/org/chzz/market/domain/user/controller/UserController.java
+++ b/src/main/java/org/chzz/market/domain/user/controller/UserController.java
@@ -18,10 +18,12 @@ import org.chzz.market.domain.user.dto.request.UserCreateRequest;
 import org.chzz.market.domain.user.dto.response.NicknameAvailabilityResponse;
 import org.chzz.market.domain.user.dto.response.UserProfileResponse;
 import org.chzz.market.domain.user.entity.User;
+import org.chzz.market.domain.user.service.UserDeleteService;
 import org.chzz.market.domain.user.service.UserService;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -37,6 +39,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 public class UserController implements UserApi {
     private final UserService userService;
+    private final UserDeleteService userDeleteService;
     private final TokenService tokenService;
 
     /**
@@ -121,6 +124,17 @@ public class UserController implements UserApi {
     @Override
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = CookieUtil.getCookieByNameOrThrow(request, TokenType.REFRESH.name());
+        tokenService.logout(refreshToken);
+        CookieUtil.expireCookie(response, TokenType.REFRESH.name());
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    @DeleteMapping
+    public ResponseEntity<Void> deleteUser(@LoginUser Long userId, HttpServletRequest request,
+                                           HttpServletResponse response) {
+        userDeleteService.delete(userId);
         String refreshToken = CookieUtil.getCookieByNameOrThrow(request, TokenType.REFRESH.name());
         tokenService.logout(refreshToken);
         CookieUtil.expireCookie(response, TokenType.REFRESH.name());

--- a/src/main/java/org/chzz/market/domain/user/dto/CustomUserDetails.java
+++ b/src/main/java/org/chzz/market/domain/user/dto/CustomUserDetails.java
@@ -35,6 +35,10 @@ public class CustomUserDetails implements OAuth2User {
 
     @Override
     public String getName() {
-        return user.getEmail();
+        return String.valueOf(user.getId());
+    }
+
+    public String getProviderId() {
+        return user.getProviderId();
     }
 }

--- a/src/main/java/org/chzz/market/domain/user/dto/UserDeletedEvent.java
+++ b/src/main/java/org/chzz/market/domain/user/dto/UserDeletedEvent.java
@@ -1,0 +1,6 @@
+package org.chzz.market.domain.user.dto;
+
+import org.chzz.market.domain.user.entity.User.ProviderType;
+
+public record UserDeletedEvent(ProviderType type, String providerId) {
+}

--- a/src/main/java/org/chzz/market/domain/user/entity/User.java
+++ b/src/main/java/org/chzz/market/domain/user/entity/User.java
@@ -53,7 +53,6 @@ public class User extends BaseTimeEntity {
 
     private String profileImageUrl;
 
-    // 구현 방식에 따라 권한 설정이 달라질 수 있어 임의로 열거체 선언 하였습니다
     @Column(columnDefinition = "varchar(20)")
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
@@ -62,7 +61,7 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private ProviderType providerType;
 
-    @Column(columnDefinition = "binary(16)", unique = true, nullable = false)
+    @Column(columnDefinition = "binary(16)", unique = true)
     private UUID customerKey;
 
     @PrePersist
@@ -93,12 +92,24 @@ public class User extends BaseTimeEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
+    public void anonymize() {
+        this.userRole = UserRole.DELETED_USER;
+        this.email = null;
+        this.nickname = "탈퇴한 사용자";
+        this.bio = null;
+        this.profileImageUrl = null;
+        this.providerId = null;
+        this.providerType = null;
+        this.customerKey = null;
+    }
+
     @Getter
     @AllArgsConstructor
     public enum UserRole {
         TEMP_USER("ROLE_TEMP_USER"),
         USER("ROLE_USER"),
-        ADMIN("ROLE_ADMIN");
+        ADMIN("ROLE_ADMIN"),
+        DELETED_USER("ROLE_DELETED_USER");
 
         private final String value;
     }

--- a/src/main/java/org/chzz/market/domain/user/error/UserErrorCode.java
+++ b/src/main/java/org/chzz/market/domain/user/error/UserErrorCode.java
@@ -1,5 +1,9 @@
 package org.chzz.market.domain.user.error;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.chzz.market.common.error.ErrorCode;
@@ -8,20 +12,28 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-    NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST, "닉네임이 중복되었습니다."),
-    USER_NOT_MATCHED(HttpStatus.BAD_REQUEST, "사용자 정보가 일치하지 않습니다."),
-    USER_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 가입된 사용자입니다."),
-    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "권한이 없는 사용자입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+    CANNOT_DELETE_USER_DUE_TO_ONGOING_AUCTIONS(BAD_REQUEST, "등록한 진행 중인 경매가 있어 회원 탈퇴가 불가능합니다."),
+    CANNOT_DELETE_USER_DUE_TO_ONGOING_BIDS(BAD_REQUEST, "참여 중인 입찰이 있어 회원 탈퇴가 불가능합니다."),
+    NICKNAME_DUPLICATION(BAD_REQUEST, "닉네임이 중복되었습니다."),
+    USER_NOT_MATCHED(BAD_REQUEST, "사용자 정보가 일치하지 않습니다."),
+    USER_ALREADY_REGISTERED(BAD_REQUEST, "이미 가입된 사용자입니다."),
+    UNAUTHORIZED_USER(UNAUTHORIZED, "권한이 없는 사용자입니다."),
+    USER_NOT_FOUND(NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    KAKAO_UNLINK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 연결 끊기에 실패했습니다."),
+    NAVER_UNLINK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "네이버 연결 끊기에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;
 
     public static class Const {
+        public static final String CANNOT_DELETE_USER_DUE_TO_ONGOING_AUCTIONS = "CANNOT_DELETE_USER_DUE_TO_ONGOING_AUCTIONS";
+        public static final String CANNOT_DELETE_USER_DUE_TO_ONGOING_BIDS = "CANNOT_DELETE_USER_DUE_TO_ONGOING_BIDS";
         public static final String NICKNAME_DUPLICATION = "NICKNAME_DUPLICATION";
         public static final String USER_NOT_MATCHED = "USER_NOT_MATCHED";
         public static final String USER_ALREADY_REGISTERED = "USER_ALREADY_REGISTERED";
         public static final String UNAUTHORIZED_USER = "UNAUTHORIZED_USER";
         public static final String USER_NOT_FOUND = "USER_NOT_FOUND";
+        public static final String KAKAO_UNLINK_FAILED = "KAKAO_UNLINK_FAILED";
+        public static final String NAVER_UNLINK_FAILED = "NAVER_UNLINK_FAILED";
     }
 }

--- a/src/main/java/org/chzz/market/domain/user/service/UserDeleteService.java
+++ b/src/main/java/org/chzz/market/domain/user/service/UserDeleteService.java
@@ -1,0 +1,58 @@
+package org.chzz.market.domain.user.service;
+
+import static org.chzz.market.domain.user.error.UserErrorCode.CANNOT_DELETE_USER_DUE_TO_ONGOING_AUCTIONS;
+import static org.chzz.market.domain.user.error.UserErrorCode.CANNOT_DELETE_USER_DUE_TO_ONGOING_BIDS;
+import static org.chzz.market.domain.user.error.UserErrorCode.USER_NOT_FOUND;
+
+import lombok.RequiredArgsConstructor;
+import org.chzz.market.domain.auction.entity.AuctionStatus;
+import org.chzz.market.domain.auction.repository.AuctionQueryRepository;
+import org.chzz.market.domain.auction.repository.AuctionRepository;
+import org.chzz.market.domain.user.dto.UserDeletedEvent;
+import org.chzz.market.domain.user.entity.User;
+import org.chzz.market.domain.user.entity.User.ProviderType;
+import org.chzz.market.domain.user.error.exception.UserException;
+import org.chzz.market.domain.user.repository.UserRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserDeleteService {
+    private final UserRepository userRepository;
+    private final AuctionRepository auctionRepository;
+    private final AuctionQueryRepository auctionQueryRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void delete(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+        // 1. 탈퇴 가능 여부 체크
+        checkDeletable(userId);
+
+        // 2. 정보 삭제 전 소셜 로그인 연결 정보 저장
+        ProviderType type = user.getProviderType();
+        String providerId = user.getProviderId();
+
+        // 3. 정보 삭제
+        user.anonymize();
+
+        // 4. 소셜 로그인 연결 끊기
+        eventPublisher.publishEvent(new UserDeletedEvent(type, providerId));
+    }
+
+    private void checkDeletable(Long userId) {
+        //1. 현재 등록한 경매 중 진행중이 있는지
+        long proceedingAuctionCount = auctionRepository.countBySellerIdAndStatusIn(userId, AuctionStatus.PROCEEDING);
+        if (proceedingAuctionCount > 0) {
+            throw new UserException(CANNOT_DELETE_USER_DUE_TO_ONGOING_AUCTIONS);
+        }
+        //2. 현재 입찰 진행 중인 경매 가 있는지
+        long proceedingBidCount = auctionQueryRepository.countProceedingAuctionsByUserId(userId);
+        if (proceedingBidCount > 0) {
+            throw new UserException(CANNOT_DELETE_USER_DUE_TO_ONGOING_BIDS);
+        }
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -95,3 +95,7 @@ logging:
 
 client:
   url: "http://test"
+
+oauth2:
+  kakao:
+    rest-api-key: testapikey

--- a/src/main/resources/db/migration/V2__modify_user_field.sql
+++ b/src/main/resources/db/migration/V2__modify_user_field.sql
@@ -1,3 +1,4 @@
 ALTER TABLE users
     MODIFY provider_id VARCHAR(255) NULL,
-    MODIFY email VARCHAR(255) NULL;
+    MODIFY email VARCHAR(255) NULL,
+    MODIFY customer_key BINARY(16) NULL;

--- a/src/main/resources/db/migration/V2__modify_user_field.sql
+++ b/src/main/resources/db/migration/V2__modify_user_field.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users
+    MODIFY provider_id VARCHAR(255) NULL,
+    MODIFY email VARCHAR(255) NULL;

--- a/src/test/java/org/chzz/market/domain/token/service/TokenServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/token/service/TokenServiceTest.java
@@ -110,19 +110,8 @@ class TokenServiceTest {
         when(refreshTokenRepository.findByToken("refresh-token")).thenReturn(Optional.empty());
 
         // when & then
-        TokenException exception = assertThrows(TokenException.class, () -> tokenService.reissue(refreshCookie.getValue()));
-        assertThat(exception.getErrorCode()).isEqualTo(TokenErrorCode.REFRESH_TOKEN_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("로그아웃 시 Refresh Token이 존재하지 않을 때 예외 발생 테스트")
-    void logout_ThrowsException_WhenTokenNotFound() {
-        // given
-        Cookie refreshCookie = new Cookie("refresh-token", "refresh-token");
-        when(refreshTokenRepository.findByToken("refresh-token")).thenReturn(Optional.empty());
-
-        // when & then
-        TokenException exception = assertThrows(TokenException.class, () -> tokenService.logout(refreshCookie.getValue()));
+        TokenException exception = assertThrows(TokenException.class,
+                () -> tokenService.reissue(refreshCookie.getValue()));
         assertThat(exception.getErrorCode()).isEqualTo(TokenErrorCode.REFRESH_TOKEN_NOT_FOUND);
     }
 }

--- a/src/test/java/org/chzz/market/domain/user/oauth2/CustomSuccessHandlerTest.java
+++ b/src/test/java/org/chzz/market/domain/user/oauth2/CustomSuccessHandlerTest.java
@@ -1,7 +1,6 @@
 package org.chzz.market.domain.user.oauth2;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -12,6 +11,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import org.chzz.market.common.filter.HttpCookieOAuth2AuthorizationRequestRepository;
+import org.chzz.market.domain.oauth2.service.CustomSuccessHandler;
 import org.chzz.market.domain.token.service.TokenService;
 import org.chzz.market.domain.user.dto.CustomUserDetails;
 import org.chzz.market.domain.user.entity.User;
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;


### PR DESCRIPTION
## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 회원 탈퇴 기능 구현
- 카카오는 어드민키로 할 수 있었지만, 네이버는 엑세스토큰으로 밖에 못해서, 일관성 있게 모두 로그인 시 리프레쉬토큰을 레디스에 저장해서 회원탈퇴 시 사용하도록 했습니다.
- 먼저 리프레쉬토큰으로 엑세스토큰을 요청받은 뒤에 각 연결끊기 API를 호출하였습니다.

## ✅Test

- 로그인시 oauth2 refreshtoken 저장
![스크린샷 2024-11-27 오전 3 51 09](https://github.com/user-attachments/assets/9f283152-8db1-4985-8ede-d941e83c9b64)

- 카카오 회원탈퇴
![스크린샷 2024-11-27 오전 3 54 50](https://github.com/user-attachments/assets/e7088438-f3ee-47ce-99f7-8a8f6529c64c)

- 네이버 회원탈퇴
![스크린샷 2024-11-27 오전 3 58 25](https://github.com/user-attachments/assets/a0e2ae06-b6ed-4bcf-8102-9a7861425513)


